### PR TITLE
mtp: route spec-verify attention to FA2 fwd_kvcache (FlashDecoding sp…

### DIFF
--- a/patches/fa2_kvcache_verify/README.md
+++ b/patches/fa2_kvcache_verify/README.md
@@ -1,0 +1,68 @@
+# FA2 `fwd_kvcache` for the MTP spec-decode verify (FlashDecoding split-KV)
+
+Routes the **MTP / speculative-decode verify attention** (the uniform `q = 1 + num_speculative`
+query tokens over a long paged KV) through the compiled-but-unwrapped FA2 op
+`torch.ops._vllm_fa2_C.fwd_kvcache` instead of `flash_attn_varlen_func`.
+
+## Problem
+
+On FA2 (Ampere sm_80/sm_86), `flash_attn_varlen_func` with `q > 1` runs the `flash_fwd_splitkv`
+kernel **without** KV-splitting — its only parallelism is `batch * num_kv_heads` tiles. At
+`num_kv_heads = 4` / `head_dim = 256` (Qwen3.5/3.6 full-attn) that is ~5% SM occupancy, and the
+per-call cost grows with KV length. Single-token decode (`q = 1`) hits the packed-GQA FlashDecoding
+path and stays fast, but the verify (`q = 1 + K`) does not — so **MTP decode goes net-negative
+beyond ~10k context** (e.g. 9B 32k: +32% @4k → −36% @32k vs no-MTP).
+
+Root cause confirmed with torch.profiler (GDN/Mamba kernels are byte-identical with/without MTP; the
+delta is entirely `flash_fwd_splitkv`) and reproduced on stock `vllm/vllm-openai:v0.23.0` and on a
+single GPU (not a fork / TP / NVLink issue). Known upstream but unfixed for FA on Ampere
+(vllm-project/vllm #14486, #6052; #40750 is MLA-only; FlashInfer's spec-as-decode is SM100-gated).
+
+## Fix
+
+`fwd_kvcache` is the FlashDecoding "append" entry — same `flash_fwd_splitkv` kernel **plus** the
+`flash_fwd_splitkv_combine` reduction, i.e. it actually splits over KV. The verify tokens are already
+in the paged cache (written by `reshape_and_cache` before attention), so we call it with `k = v =
+None`, `seqlens_k = full per-request length`, `causal = True`, `num_splits = 0`. It reproduces
+`flash_attn_varlen_func` (q=1 cos=1.000000, q=3 cos=0.999996 — bf16 split-combine rounding) at
+**~4.3× the kernel speed** (32k: 2.84ms → 0.66ms), and is **cudagraph-capturable at num_splits=0**
+(PyTorch's graph private pool captures the combine workspace) — so it captures into the FULL
+cudagraph and the win lands in the real serve.
+
+## Measured (OpenAI API, cudagraph, decode tok/s)
+
+| model | ctx | MTP off-patch | MTP on-patch | gain |
+|-------|-----|---------------|--------------|------|
+| 9B  (tp1) | 16k | 68.2 | 104.7 | +54% |
+| 9B  (tp1) | 32k | 50.4 | 88.6  | +76% |
+| 27B (tp2) | 16k | 55.2 | 88.2  | +60% |
+| 27B (tp2) | 32k | 39.7 | 81.9  | +106% |
+
+MTP is now **net-positive at every context and beats no-MTP** (27B 32k: 81.9 vs no-MTP 61, +34%).
+`accept-len` is preserved (9B 2.1–2.3, 27B 2.6–3.0 — the correctness canary), `VLLM_FA2_KVCACHE_VERIFY=0`
+is byte-identical to baseline, and prefill / non-spec decode are untouched.
+
+## Files changed (see `fa2-kvcache-verify.patch`)
+
+- `vllm/vllm_flash_attn/flash_attn_interface.py` — `flash_attn_kvcache_verify` wrapper (+ import-time
+  schema-arity==20 assert).
+- `vllm/vllm_flash_attn/__init__.py`, `vllm/v1/attention/backends/fa_utils.py` — re-export.
+- `vllm/v1/attention/backends/flash_attn.py` — guarded import + the dispatch in
+  `FlashAttentionImpl.forward` (non-cascade branch).
+- `vllm/envs.py` — `VLLM_FA2_KVCACHE_VERIFY` (default on).
+
+The dispatch predicate is all-AND and falls back to the unchanged `flash_attn_varlen_func` for every
+unsupported case (fp8/quantized KV, sliding window, alibi, softcap, sinks, FA3, batch-invariant,
+non-uniform / prefill-mixed batches), so blast radius on un-targeted models is zero.
+
+## Tests
+
+Standalone kernel tests (need a CUDA box with the FA2 extension; no model download):
+
+- `correctness_probe.py` — `fwd_kvcache` vs `flash_attn_varlen_func`, cos > 0.9999 for q∈{1,3} @ {4k,16k,32k}.
+- `wrapper_test.py` — the shipped `flash_attn_kvcache_verify` wrapper (in-place out) vs varlen.
+- `capturability_test.py` — capture `fwd_kvcache` in a CUDA graph, replay, assert correct.
+- `kvcache_bench.py` / `kernel_name_probe.py` — the ~4.3× speedup and the `splitkv + combine` evidence.
+
+E2E (serve + OpenAI API): set `VLLM_FA2_KVCACHE_VERIFY=1` vs `0`, MTP on, compare decode at 16k/32k;
+`accept-len` from the `SpecDecoding metrics` log line must stay ~2.1–3.0.

--- a/patches/fa2_kvcache_verify/capturability_test.py
+++ b/patches/fa2_kvcache_verify/capturability_test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Can fwd_kvcache be captured in a CUDA graph? num_splits=0 picks a runtime-sized combine
+workspace (likely not capturable); a FIXED num_splits should give a fixed workspace -> capturable.
+If NS=32 captures + replays correct, patch A v2 (pass attn_metadata.max_num_splits, drop the
+is_current_stream_capturing guard) realizes the verify win inside the FULL cudagraph serve."""
+import torch
+import torch.nn.functional as F
+from vllm.vllm_flash_attn import _vllm_fa2_C  # noqa: F401
+
+op = torch.ops._vllm_fa2_C.fwd_kvcache
+dev, dt = "cuda", torch.bfloat16
+D, Hq, Hkv, BS, kv, B, ql = 256, 16, 4, 16, 32768, 1, 3
+torch.manual_seed(0)
+nblk = (kv + BS - 1) // BS
+q = torch.randn(B, ql, Hq, D, device=dev, dtype=dt)
+kc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+vc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+bt = torch.arange(B * nblk, device=dev, dtype=torch.int32).reshape(B, nblk)
+seqk = torch.full((B,), kv, device=dev, dtype=torch.int32)
+out = torch.empty(B, ql, Hq, D, device=dev, dtype=dt)
+
+
+def call(ns):
+    op(q, kc, vc, None, None, seqk, None, None, None, None, bt, None, out,
+       D ** -0.5, True, -1, -1, 0.0, False, ns)
+
+
+for NS in [0, 32]:
+    call(NS)
+    torch.cuda.synchronize()
+    ref = out.clone()
+    try:
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(3):
+                call(NS)
+        torch.cuda.current_stream().wait_stream(s)
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            call(NS)
+        out.zero_()
+        g.replay()
+        torch.cuda.synchronize()
+        cos = F.cosine_similarity(ref.float().flatten(), out.float().flatten(), dim=0).item()
+        print(f"num_splits={NS:2d}: CAPTURE OK, replay cos={cos:.6f}  "
+              f"{'(matches)' if cos > 0.999 else '*** REPLAY WRONG ***'}")
+    except Exception as e:
+        print(f"num_splits={NS:2d}: CAPTURE FAILED -> {str(e)[:140]}")

--- a/patches/fa2_kvcache_verify/correctness_probe.py
+++ b/patches/fa2_kvcache_verify/correctness_probe.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Correctness gate: does fwd_kvcache reproduce flash_attn_varlen_func for the verify shape?
+Same paged KV, same q, cache_seqlens=full (new verify tokens already written to cache by
+reshape_and_cache before attn), causal=True. If cos~=1, fwd_kvcache is a drop-in for the verify."""
+import torch
+import torch.nn.functional as F
+from vllm.vllm_flash_attn import flash_attn_varlen_func, _vllm_fa2_C  # noqa: F401
+
+op = torch.ops._vllm_fa2_C.fwd_kvcache
+dev, dt = "cuda", torch.bfloat16
+D, Hq, Hkv, BS = 256, 16, 4, 16
+torch.manual_seed(0)
+
+
+def test(B, ql, kv):
+    nblk = (kv + BS - 1) // BS
+    kc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+    vc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+    bt = torch.arange(B * nblk, device=dev, dtype=torch.int32).reshape(B, nblk)
+    seqk = torch.full((B,), kv, device=dev, dtype=torch.int32)
+    qd = torch.randn(B, ql, Hq, D, device=dev, dtype=dt)
+    # varlen: packed q [B*ql, H, D]
+    qv = qd.reshape(B * ql, Hq, D)
+    cu = torch.arange(0, B * ql + 1, ql, device=dev, dtype=torch.int32)
+    out_v = torch.empty_like(qv)
+    flash_attn_varlen_func(q=qv, k=kc, v=vc, out=out_v, cu_seqlens_q=cu, max_seqlen_q=ql,
+                           seqused_k=seqk, max_seqlen_k=kv, softmax_scale=D ** -0.5,
+                           causal=True, block_table=bt)
+    # fwd_kvcache: q [B, ql, H, D]; k/v=None (verify tokens already in cache); causal
+    res = op(qd, kc, vc, None, None, seqk, None, None, None, None, bt, None, None,
+             D ** -0.5, True, -1, -1, 0.0, False, 0)
+    out_k = (res[0] if isinstance(res, (list, tuple)) else res).reshape(B, ql, Hq, D)
+    a = out_v.reshape(B, ql, Hq, D).float()
+    b = out_k.float()
+    cos = F.cosine_similarity(a.flatten(), b.flatten(), dim=0).item()
+    return cos, (a - b).abs().max().item(), a.abs().mean().item()
+
+
+for kv in [4096, 16384, 32768]:
+    for ql in [1, 3]:
+        cos, md, scale = test(1, ql, kv)
+        flag = "OK" if cos > 0.999 else "*** MISMATCH ***"
+        print(f"kv={kv:6d} q={ql}: cos={cos:.6f}  maxdiff={md:.4f}  (scale~{scale:.3f})  {flag}", flush=True)

--- a/patches/fa2_kvcache_verify/fa2-kvcache-verify.patch
+++ b/patches/fa2_kvcache_verify/fa2-kvcache-verify.patch
@@ -1,0 +1,190 @@
+diff --git a/vllm/vllm/envs.py b/vllm/vllm/envs.py
+index bea9280..2f36f8b 100755
+--- a/vllm/vllm/envs.py
++++ b/vllm/vllm/envs.py
+@@ -85,6 +85,7 @@ if TYPE_CHECKING:
+     VLLM_MAIN_CUDA_VERSION: str = "13.0"
+     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
+     VLLM_BATCH_INVARIANT: bool = False
++    VLLM_FA2_KVCACHE_VERIFY: bool = True
+     VLLM_TRITON_ATTN_USE_TD: bool | None = None
+     MAX_JOBS: str | None = None
+     NVCC_THREADS: str | None = None
+@@ -596,6 +597,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     # Enable batch-invariant mode: deterministic results regardless of
+     # batch composition. Requires NVIDIA GPU with compute capability >= 9.0.
+     "VLLM_BATCH_INVARIANT": lambda: bool(int(os.getenv("VLLM_BATCH_INVARIANT", "0"))),
++    # [Ampere fork] Route the MTP spec-decode verify (uniform q=1+K) attention through the
++    # compiled FA2 fwd_kvcache (FlashDecoding split-KV) instead of flash_attn_varlen_func, which
++    # on FA2 runs splitkv with only batch*Hkv tiles (occupancy-starved at low Hkv / head_dim=256,
++    # cost grows with KV length -> MTP net-negative beyond ~10k ctx). Default on; opt out with "0".
++    "VLLM_FA2_KVCACHE_VERIFY": lambda: bool(
++        int(os.getenv("VLLM_FA2_KVCACHE_VERIFY", "1"))
++    ),
+     # [Ampere fork] Opt in to the int8-QK prefill attention backend (patch 0004): when "1",
+     # the `vllm.general_plugins` entry-point `register_int8qk` overrides the FLASH_ATTN backend
+     # with the int8-QK + fp16-PV prefill path for hd256 full-attn layers (everything else
+diff --git a/vllm/vllm/v1/attention/backends/fa_utils.py b/vllm/vllm/v1/attention/backends/fa_utils.py
+index 0d6a3d2..3bd95e0 100644
+--- a/vllm/vllm/v1/attention/backends/fa_utils.py
++++ b/vllm/vllm/v1/attention/backends/fa_utils.py
+@@ -18,6 +18,7 @@ _ROCM_FLASH_ATTN_AVAILABLE = False
+ if current_platform.is_cuda():
+     from vllm._custom_ops import reshape_and_cache_flash
+     from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
++        flash_attn_kvcache_verify,
+         flash_attn_varlen_func,
+         get_scheduler_metadata,
+     )
+diff --git a/vllm/vllm/v1/attention/backends/flash_attn.py b/vllm/vllm/v1/attention/backends/flash_attn.py
+index c56c4ee..d92ee4e 100755
+--- a/vllm/vllm/v1/attention/backends/flash_attn.py
++++ b/vllm/vllm/v1/attention/backends/flash_attn.py
+@@ -35,6 +35,7 @@ from vllm.v1.worker.workspace import current_workspace_manager
+ 
+ if is_flash_attn_varlen_func_available():
+     from vllm.v1.attention.backends.fa_utils import (
++        flash_attn_kvcache_verify,
+         flash_attn_supports_sinks,
+         flash_attn_varlen_func,
+         get_scheduler_metadata,
+@@ -793,6 +794,42 @@ class FlashAttentionImpl(AttentionImpl):
+                     if self.sliding_window is not None
+                     else None
+                 )
++                # [Ampere fork] MTP spec-decode verify (uniform q=1+K over a long
++                # paged KV) -> FA2 fwd_kvcache (FlashDecoding split-KV). FA2 varlen
++                # with q>1 does not KV-split (occupancy-starved at low num_kv_heads /
++                # head_dim=256, cost grows with KV length); fwd_kvcache is captured
++                # into the FULL cudagraph (proven capturable at num_splits=0) and
++                # recovers MTP from net-negative to net-positive at long context
++                # (9B: +54% @16k, +76% @32k decode). Every AND-term below falls back
++                # to the unchanged varlen call, so prefill / chunked-prefill / mixed
++                # batches / fp8-KV / SWA / alibi / softcap / sinks are untouched.
++                q_len = max_seqlen_q
++                num_reqs = seqused_k.shape[0]
++                if (
++                    envs.VLLM_FA2_KVCACHE_VERIFY
++                    and self.vllm_flash_attn_version == 2
++                    and q_len > 1
++                    and num_actual_tokens == num_reqs * q_len
++                    and self.sliding_window == (-1, -1)
++                    and self.alibi_slopes is None
++                    and self.logits_soft_cap == 0
++                    and self.sinks is None
++                    and not is_quantized_kv_cache(self.kv_cache_dtype)
++                    and not envs.VLLM_BATCH_INVARIANT
++                ):
++                    flash_attn_kvcache_verify(
++                        q=query[:num_actual_tokens],
++                        k_cache=key_cache,
++                        v_cache=value_cache,
++                        out=output[:num_actual_tokens],
++                        seqlens_k=seqused_k,
++                        block_table=block_table,
++                        num_reqs=num_reqs,
++                        q_len=q_len,
++                        softmax_scale=self.scale,
++                        causal=attn_metadata.causal,
++                    )
++                    return output
+                 flash_attn_varlen_func(
+                     q=query[:num_actual_tokens],
+                     k=key_cache,
+diff --git a/vllm/vllm/vllm_flash_attn/__init__.py b/vllm/vllm/vllm_flash_attn/__init__.py
+index 7dea1f6..82cf264 100644
+--- a/vllm/vllm/vllm_flash_attn/__init__.py
++++ b/vllm/vllm/vllm_flash_attn/__init__.py
+@@ -24,6 +24,7 @@ from vllm.vllm_flash_attn.flash_attn_interface import (  # noqa: E402
+     FA2_AVAILABLE,
+     FA3_AVAILABLE,
+     fa_version_unsupported_reason,
++    flash_attn_kvcache_verify,
+     flash_attn_varlen_func,
+     get_scheduler_metadata,
+     is_fa_version_supported,
+@@ -37,6 +38,7 @@ if not (FA2_AVAILABLE or FA3_AVAILABLE):
+ 
+ __all__ = [
+     "fa_version_unsupported_reason",
++    "flash_attn_kvcache_verify",
+     "flash_attn_varlen_func",
+     "get_scheduler_metadata",
+     "is_fa_version_supported",
+diff --git a/vllm/vllm/vllm_flash_attn/flash_attn_interface.py b/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
+index 33955bb..8f496a1 100644
+--- a/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
++++ b/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
+@@ -394,6 +394,72 @@ def flash_attn_varlen_func(
+     return (out, softmax_lse) if return_softmax_lse else out
+ 
+ 
++_FWD_KVCACHE_ARITY_OK = False
++
++
++def flash_attn_kvcache_verify(
++    q,
++    k_cache,
++    v_cache,
++    out,
++    seqlens_k,
++    block_table,
++    num_reqs,
++    q_len,
++    softmax_scale,
++    causal=True,
++):
++    """FlashDecoding split-KV path for uniform q=1+K MTP spec-verify batches.
++
++    FA2 ``flash_attn_varlen_func`` with q>1 runs splitkv with only batch*Hkv
++    tiles (occupancy-starved at low num_kv_heads / head_dim=256, cost grows with
++    KV length). ``fwd_kvcache`` adds the split-combine kernel so it actually
++    splits over KV (~4.3x at 32k ctx). The verify tokens are already in the paged
++    cache (written by reshape_and_cache before attention), so k/v are None and
++    ``seqlens_k`` is the full per-request length. Reshapes the flat
++    [num_actual_tokens, H, D] query to [num_reqs, q_len, H, D] (free view on the
++    contiguous slice) and writes ``out`` in place.
++    """
++    global _FWD_KVCACHE_ARITY_OK
++    if not _FWD_KVCACHE_ARITY_OK:
++        n_args = len(torch.ops._vllm_fa2_C.fwd_kvcache.default._schema.arguments)
++        assert n_args == 20, (
++            f"_vllm_fa2_C.fwd_kvcache schema arity {n_args} != 20; "
++            "flash_attn_kvcache_verify positional args need review"
++        )
++        _FWD_KVCACHE_ARITY_OK = True
++    h, d = q.shape[-2], q.shape[-1]
++    q4 = q.view(num_reqs, q_len, h, d)
++    out4 = out.view(num_reqs, q_len, h, d)
++    # positional order == _vllm_fa2_C.fwd_kvcache schema:
++    # (q, kcache, vcache, k, v, seqlens_k, rotary_cos, rotary_sin, cache_batch_idx,
++    #  leftpad_k, block_table, alibi_slopes, out, softmax_scale, is_causal,
++    #  window_size_left, window_size_right, softcap, is_rotary_interleaved, num_splits)
++    torch.ops._vllm_fa2_C.fwd_kvcache(
++        q4,
++        k_cache,
++        v_cache,
++        None,  # k: verify tokens already written to cache
++        None,  # v
++        seqlens_k,
++        None,  # rotary_cos
++        None,  # rotary_sin
++        None,  # cache_batch_idx
++        None,  # leftpad_k
++        block_table,
++        None,  # alibi_slopes
++        out4,  # written in place; shares storage with `out`
++        softmax_scale,
++        causal,
++        -1,  # window_size_left (full context)
++        -1,  # window_size_right
++        0.0,  # softcap off
++        False,  # is_rotary_interleaved
++        0,  # num_splits = 0 -> kernel auto-splits over KV
++    )
++    return out
++
++
+ def sparse_attn_func(
+     q,
+     k,

--- a/patches/fa2_kvcache_verify/kernel_name_probe.py
+++ b/patches/fa2_kvcache_verify/kernel_name_probe.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Name the actual CUDA kernel behind varlen-q3 (slow) vs fwd_kvcache-q3 (fast) at 32k, verify shape."""
+import torch
+from torch.profiler import ProfilerActivity, profile
+from vllm.vllm_flash_attn import flash_attn_varlen_func, _vllm_fa2_C  # noqa: F401
+
+op = torch.ops._vllm_fa2_C.fwd_kvcache
+dev, dt = "cuda", torch.bfloat16
+D, Hq, Hkv, BS, kv, B, ql = 256, 16, 4, 16, 32768, 1, 3
+nblk = (kv + BS - 1) // BS
+kc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+vc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+bt = torch.arange(B * nblk, device=dev, dtype=torch.int32).reshape(B, nblk)
+seqk = torch.full((B,), kv, device=dev, dtype=torch.int32)
+qv = torch.randn(B * ql, Hq, D, device=dev, dtype=dt)
+cu = torch.tensor([0, ql], device=dev, dtype=torch.int32)
+qk = torch.randn(B, ql, Hq, D, device=dev, dtype=dt)
+
+
+def varlen():
+    flash_attn_varlen_func(q=qv, k=kc, v=vc, cu_seqlens_q=cu, max_seqlen_q=ql, seqused_k=seqk,
+                           max_seqlen_k=kv, softmax_scale=D ** -0.5, causal=True, block_table=bt)
+
+
+def kvc():
+    op(qk, kc, vc, None, None, seqk, None, None, None, None, bt, None, None,
+       D ** -0.5, True, -1, -1, 0.0, False, 0)
+
+
+for name, fn in [("VARLEN-q3 (slow)", varlen), ("FWD_KVCACHE-q3 (fast)", kvc)]:
+    for _ in range(5):
+        fn()
+    torch.cuda.synchronize()
+    with profile(activities=[ProfilerActivity.CUDA]) as p:
+        for _ in range(20):
+            fn()
+    torch.cuda.synchronize()
+    print(f"==== {name} ====")
+    print(p.key_averages().table(sort_by="cuda_time_total", row_limit=5))

--- a/patches/fa2_kvcache_verify/kvcache_bench.py
+++ b/patches/fa2_kvcache_verify/kvcache_bench.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Test the REAL fast path: torch.ops._vllm_fa2_C.fwd_kvcache (compiled but unwrapped) at the MTP
+verify shape (q=1+K, Hq=16,Hkv=4,D=256, paged, causal), vs the varlen baseline. fwd_kvcache supports
+num_splits on FA2 (varlen does not) -> FlashDecoding KV-split for q>1. If q3 fwd_kvcache ~ q1 speed,
+forcing this path is the fix."""
+import time
+
+import torch
+from vllm.vllm_flash_attn import _vllm_fa2_C  # noqa: F401  (registers the op)
+
+op = torch.ops._vllm_fa2_C.fwd_kvcache
+dev, dt = "cuda", torch.bfloat16
+D, Hq, Hkv, BS = 256, 16, 4, 16
+torch.manual_seed(0)
+
+
+def bench(B, q_len, kv_len, ns, iters=50):
+    nblk = (kv_len + BS - 1) // BS
+    q = torch.randn(B, q_len, Hq, D, device=dev, dtype=dt)
+    kc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+    vc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+    bt = torch.arange(B * nblk, device=dev, dtype=torch.int32).reshape(B, nblk)
+    seqk = torch.full((B,), kv_len, device=dev, dtype=torch.int32)
+
+    def run():
+        # (q, kcache, vcache, k, v, seqlens_k, rotary_cos, rotary_sin, cache_batch_idx,
+        #  leftpad_k, block_table, alibi_slopes, out, softmax_scale, is_causal,
+        #  window_size_left, window_size_right, softcap, is_rotary_interleaved, num_splits)
+        op(q, kc, vc, None, None, seqk, None, None, None, None, bt, None, None,
+           D ** -0.5, True, -1, -1, 0.0, False, ns)
+
+    for _ in range(5):
+        run()
+    torch.cuda.synchronize()
+    t = time.time()
+    for _ in range(iters):
+        run()
+    torch.cuda.synchronize()
+    return (time.time() - t) / iters * 1e3
+
+
+for kv in [4096, 16384, 32768]:
+    cells = []
+    for ql in [1, 3]:
+        for ns in [0, 8, 16, 32]:
+            try:
+                cells.append(f"q{ql}/ns{ns}={bench(1, ql, kv, ns):.3f}")
+            except Exception as e:
+                cells.append(f"q{ql}/ns{ns}=ERR({str(e)[:45]})")
+    print(f"kv={kv:6d}: " + "  ".join(cells), flush=True)

--- a/patches/fa2_kvcache_verify/wrapper_test.py
+++ b/patches/fa2_kvcache_verify/wrapper_test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Validate the SHIPPED wrapper flash_attn_kvcache_verify (in-place out + arity self-check) against
+flash_attn_varlen_func at the forward call shape (flat q=[N,H,D], in-place out)."""
+import torch
+import torch.nn.functional as F
+
+import vllm.envs as envs
+from vllm.vllm_flash_attn import flash_attn_kvcache_verify, flash_attn_varlen_func
+
+print("env VLLM_FA2_KVCACHE_VERIFY default:", envs.VLLM_FA2_KVCACHE_VERIFY)
+dev, dt = "cuda", torch.bfloat16
+D, Hq, Hkv, BS = 256, 16, 4, 16
+torch.manual_seed(0)
+
+
+def test(B, ql, kv):
+    nblk = (kv + BS - 1) // BS
+    kc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+    vc = torch.randn(B * nblk + 1, BS, Hkv, D, device=dev, dtype=dt)
+    bt = torch.arange(B * nblk, device=dev, dtype=torch.int32).reshape(B, nblk)
+    seqk = torch.full((B,), kv, device=dev, dtype=torch.int32)
+    qflat = torch.randn(B * ql, Hq, D, device=dev, dtype=dt)
+    ov = torch.empty_like(qflat)
+    cu = torch.arange(0, B * ql + 1, ql, device=dev, dtype=torch.int32)
+    flash_attn_varlen_func(q=qflat, k=kc, v=vc, out=ov, cu_seqlens_q=cu, max_seqlen_q=ql,
+                           seqused_k=seqk, max_seqlen_k=kv, softmax_scale=D ** -0.5,
+                           causal=True, block_table=bt)
+    ok = torch.empty_like(qflat)  # in-place target, as in forward (output[:N])
+    flash_attn_kvcache_verify(q=qflat, k_cache=kc, v_cache=vc, out=ok, seqlens_k=seqk,
+                              block_table=bt, num_reqs=B, q_len=ql, softmax_scale=D ** -0.5,
+                              causal=True)
+    return F.cosine_similarity(ov.float().flatten(), ok.float().flatten(), dim=0).item()
+
+
+bad = 0
+for kv in [4096, 16384, 32768]:
+    for ql in [1, 3]:
+        cos = test(1, ql, kv)
+        ok = cos > 0.9999
+        bad += not ok
+        print(f"kv={kv:6d} q={ql}: wrapper-vs-varlen cos={cos:.6f}  {'OK' if ok else '*** FAIL ***'}")
+print("ALL PASS" if bad == 0 else f"{bad} FAILED")

--- a/vllm/vllm/envs.py
+++ b/vllm/vllm/envs.py
@@ -85,6 +85,7 @@ if TYPE_CHECKING:
     VLLM_MAIN_CUDA_VERSION: str = "13.0"
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
+    VLLM_FA2_KVCACHE_VERIFY: bool = True
     VLLM_TRITON_ATTN_USE_TD: bool | None = None
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
@@ -596,6 +597,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable batch-invariant mode: deterministic results regardless of
     # batch composition. Requires NVIDIA GPU with compute capability >= 9.0.
     "VLLM_BATCH_INVARIANT": lambda: bool(int(os.getenv("VLLM_BATCH_INVARIANT", "0"))),
+    # [Ampere fork] Route the MTP spec-decode verify (uniform q=1+K) attention through the
+    # compiled FA2 fwd_kvcache (FlashDecoding split-KV) instead of flash_attn_varlen_func, which
+    # on FA2 runs splitkv with only batch*Hkv tiles (occupancy-starved at low Hkv / head_dim=256,
+    # cost grows with KV length -> MTP net-negative beyond ~10k ctx). Default on; opt out with "0".
+    "VLLM_FA2_KVCACHE_VERIFY": lambda: bool(
+        int(os.getenv("VLLM_FA2_KVCACHE_VERIFY", "1"))
+    ),
     # [Ampere fork] Opt in to the int8-QK prefill attention backend (patch 0004): when "1",
     # the `vllm.general_plugins` entry-point `register_int8qk` overrides the FLASH_ATTN backend
     # with the int8-QK + fp16-PV prefill path for hd256 full-attn layers (everything else

--- a/vllm/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/vllm/v1/attention/backends/fa_utils.py
@@ -18,6 +18,7 @@ _ROCM_FLASH_ATTN_AVAILABLE = False
 if current_platform.is_cuda():
     from vllm._custom_ops import reshape_and_cache_flash
     from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
+        flash_attn_kvcache_verify,
         flash_attn_varlen_func,
         get_scheduler_metadata,
     )

--- a/vllm/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/vllm/v1/attention/backends/flash_attn.py
@@ -35,6 +35,7 @@ from vllm.v1.worker.workspace import current_workspace_manager
 
 if is_flash_attn_varlen_func_available():
     from vllm.v1.attention.backends.fa_utils import (
+        flash_attn_kvcache_verify,
         flash_attn_supports_sinks,
         flash_attn_varlen_func,
         get_scheduler_metadata,
@@ -793,6 +794,42 @@ class FlashAttentionImpl(AttentionImpl):
                     if self.sliding_window is not None
                     else None
                 )
+                # [Ampere fork] MTP spec-decode verify (uniform q=1+K over a long
+                # paged KV) -> FA2 fwd_kvcache (FlashDecoding split-KV). FA2 varlen
+                # with q>1 does not KV-split (occupancy-starved at low num_kv_heads /
+                # head_dim=256, cost grows with KV length); fwd_kvcache is captured
+                # into the FULL cudagraph (proven capturable at num_splits=0) and
+                # recovers MTP from net-negative to net-positive at long context
+                # (9B: +54% @16k, +76% @32k decode). Every AND-term below falls back
+                # to the unchanged varlen call, so prefill / chunked-prefill / mixed
+                # batches / fp8-KV / SWA / alibi / softcap / sinks are untouched.
+                q_len = max_seqlen_q
+                num_reqs = seqused_k.shape[0]
+                if (
+                    envs.VLLM_FA2_KVCACHE_VERIFY
+                    and self.vllm_flash_attn_version == 2
+                    and q_len > 1
+                    and num_actual_tokens == num_reqs * q_len
+                    and self.sliding_window == (-1, -1)
+                    and self.alibi_slopes is None
+                    and self.logits_soft_cap == 0
+                    and self.sinks is None
+                    and not is_quantized_kv_cache(self.kv_cache_dtype)
+                    and not envs.VLLM_BATCH_INVARIANT
+                ):
+                    flash_attn_kvcache_verify(
+                        q=query[:num_actual_tokens],
+                        k_cache=key_cache,
+                        v_cache=value_cache,
+                        out=output[:num_actual_tokens],
+                        seqlens_k=seqused_k,
+                        block_table=block_table,
+                        num_reqs=num_reqs,
+                        q_len=q_len,
+                        softmax_scale=self.scale,
+                        causal=attn_metadata.causal,
+                    )
+                    return output
                 flash_attn_varlen_func(
                     q=query[:num_actual_tokens],
                     k=key_cache,

--- a/vllm/vllm/vllm_flash_attn/__init__.py
+++ b/vllm/vllm/vllm_flash_attn/__init__.py
@@ -24,6 +24,7 @@ from vllm.vllm_flash_attn.flash_attn_interface import (  # noqa: E402
     FA2_AVAILABLE,
     FA3_AVAILABLE,
     fa_version_unsupported_reason,
+    flash_attn_kvcache_verify,
     flash_attn_varlen_func,
     get_scheduler_metadata,
     is_fa_version_supported,
@@ -37,6 +38,7 @@ if not (FA2_AVAILABLE or FA3_AVAILABLE):
 
 __all__ = [
     "fa_version_unsupported_reason",
+    "flash_attn_kvcache_verify",
     "flash_attn_varlen_func",
     "get_scheduler_metadata",
     "is_fa_version_supported",

--- a/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
+++ b/vllm/vllm/vllm_flash_attn/flash_attn_interface.py
@@ -394,6 +394,72 @@ def flash_attn_varlen_func(
     return (out, softmax_lse) if return_softmax_lse else out
 
 
+_FWD_KVCACHE_ARITY_OK = False
+
+
+def flash_attn_kvcache_verify(
+    q,
+    k_cache,
+    v_cache,
+    out,
+    seqlens_k,
+    block_table,
+    num_reqs,
+    q_len,
+    softmax_scale,
+    causal=True,
+):
+    """FlashDecoding split-KV path for uniform q=1+K MTP spec-verify batches.
+
+    FA2 ``flash_attn_varlen_func`` with q>1 runs splitkv with only batch*Hkv
+    tiles (occupancy-starved at low num_kv_heads / head_dim=256, cost grows with
+    KV length). ``fwd_kvcache`` adds the split-combine kernel so it actually
+    splits over KV (~4.3x at 32k ctx). The verify tokens are already in the paged
+    cache (written by reshape_and_cache before attention), so k/v are None and
+    ``seqlens_k`` is the full per-request length. Reshapes the flat
+    [num_actual_tokens, H, D] query to [num_reqs, q_len, H, D] (free view on the
+    contiguous slice) and writes ``out`` in place.
+    """
+    global _FWD_KVCACHE_ARITY_OK
+    if not _FWD_KVCACHE_ARITY_OK:
+        n_args = len(torch.ops._vllm_fa2_C.fwd_kvcache.default._schema.arguments)
+        assert n_args == 20, (
+            f"_vllm_fa2_C.fwd_kvcache schema arity {n_args} != 20; "
+            "flash_attn_kvcache_verify positional args need review"
+        )
+        _FWD_KVCACHE_ARITY_OK = True
+    h, d = q.shape[-2], q.shape[-1]
+    q4 = q.view(num_reqs, q_len, h, d)
+    out4 = out.view(num_reqs, q_len, h, d)
+    # positional order == _vllm_fa2_C.fwd_kvcache schema:
+    # (q, kcache, vcache, k, v, seqlens_k, rotary_cos, rotary_sin, cache_batch_idx,
+    #  leftpad_k, block_table, alibi_slopes, out, softmax_scale, is_causal,
+    #  window_size_left, window_size_right, softcap, is_rotary_interleaved, num_splits)
+    torch.ops._vllm_fa2_C.fwd_kvcache(
+        q4,
+        k_cache,
+        v_cache,
+        None,  # k: verify tokens already written to cache
+        None,  # v
+        seqlens_k,
+        None,  # rotary_cos
+        None,  # rotary_sin
+        None,  # cache_batch_idx
+        None,  # leftpad_k
+        block_table,
+        None,  # alibi_slopes
+        out4,  # written in place; shares storage with `out`
+        softmax_scale,
+        causal,
+        -1,  # window_size_left (full context)
+        -1,  # window_size_right
+        0.0,  # softcap off
+        False,  # is_rotary_interleaved
+        0,  # num_splits = 0 -> kernel auto-splits over KV
+    )
+    return out
+
+
 def sparse_attn_func(
     q,
     k,


### PR DESCRIPTION
…lit-KV)

FA2 flash_attn_varlen_func with q>1 -- the MTP verify's uniform 1+K query tokens -- runs splitkv with only batch*num_kv_heads tiles, occupancy-starved at num_kv_heads=4 / head_dim=256 with cost growing in KV length, so MTP decode goes net-negative beyond ~10k ctx. Route the uniform verify through the compiled-but- unwrapped torch.ops._vllm_fa2_C.fwd_kvcache (FlashDecoding: adds the split-combine so it KV-splits like single-token decode). It reproduces varlen (q=3 cos=0.999996), is ~4.3x the kernel speed, and is cudagraph-capturable at num_splits=0 so it captures into the FULL cudagraph and the win lands in the real serve.

Measured (OpenAI API, cudagraph): MTP decode recovers from net-negative to net- positive at long ctx -- 9B tp1 +54%/+76% @16k/32k, 27B tp2 +60%/+106% @16k/32k; beats no-MTP everywhere. accept-len preserved (2.1-3.0), the default-off path is byte-identical to baseline, prefill / non-spec untouched. Gated by VLLM_FA2_KVCACHE_VERIFY (default on); fp8-KV / SWA / alibi / softcap / sinks / FA3 / batch-invariant / mixed batches all fall back to varlen.

See patches/fa2_kvcache_verify/ for the standalone tests and patch file.