### PR TITLE
v0.4.1 — spec-decode correctness fix (GDN-hybrid K+1 prompt) + flashampere routing/xqa_verify fixes

### DIFF
--- a/docs/release_notes_v0.4.1.md
+++ b/docs/release_notes_v0.4.1.md
@@ -1,0 +1,9 @@
+**Patch release on v0.4 (same vendored vLLM 0.25.1). Primarily a spec-decode correctness fix.**
+
+- **Fix (spec-decode correctness):** GDN-hybrid models (Qwen3.6 / Qwen3-Next) + speculative decoding produced garbage when a prompt tokenized to **exactly `num_speculative_tokens + 1` tokens**. An upstream vLLM `_is_uniform_decode` shape-only check mis-dispatched that prefill through the FULL spec-verify CUDA graph, skipping the recurrent-state write. Affects MTP / DSpark / DFlash / ngram, any quantization; short raw-completion prompts (chat-template traffic is effectively immune). Also filed upstream (vllm#49918, PR #47123).
+- **Fix (flashampere):** the 0.25.1 `sliding_window=(-1,-1)` sentinel was treated as a real window, which had **disabled all hd≤256 flashampere routing in the v0.4 image** (including the 27B hd128 flagship). Restored.
+- **Fix (flashampere xqa_verify):** the MTP spec-verify leg is now prewarmed before CUDA-graph capture (it was silently declining every verify to stock FA); cleanly self-disables on mamba-aligned hybrid page geometry instead of erroring; padded-batch reshape crash fixed.
+- **DSpark:** accepts the upstream / DeepSeek-official head format (`Qwen3DSparkModel`) — one checkpoint now serves both this fork and upstream vLLM ≥ 0.26.
+- **flashampere prefill:** opt-in batched paged-KV prefill (`VLLM_FAMP_BATCH_PREFILL=1`, default off) — +2.3% / +4.5% clean full-prefill @ 4k / 8k; `CTA_TILE_Q=64` on sm86 for hd128 (+6–18% short/mid prefill); sync-free leg dispatch.
+
+Image: `ghcr.io/avesed/vllm-ampere-optimized:0.4.1` · `:latest` · `:v0.25.1-ampere-cu130` (from-source, full multi-arch). No-NVLink multi-GPU: add `--disable-custom-all-reduce`.

--- a/eval/gsm8k_eval.py
+++ b/eval/gsm8k_eval.py
@@ -138,6 +138,7 @@ def main():
     ap.add_argument("--top-p", type=float, default=0.95)
     ap.add_argument("--seed", type=int, default=1234)
     ap.add_argument("--gpu-mem", type=float, default=0.92)
+    ap.add_argument("--tp", type=int, default=1)
     ap.add_argument("--smoke", action="store_true")
     args = ap.parse_args()
 
@@ -174,6 +175,10 @@ def main():
         dtype="float16",
         max_model_len=args.max_model_len,
         max_num_seqs=args.max_num_seqs,
+        tensor_parallel_size=args.tp,
+        # Ampere fork convention: custom-AR crashes at init with expandable_segments
+        # (custom_all_reduce.cuh:455 'invalid argument') and garbles non-English on 2x3090.
+        disable_custom_all_reduce=True,
         gpu_memory_utilization=args.gpu_mem,
         enforce_eager=False,
         seed=args.seed,

--- a/flashampere/backend.py
+++ b/flashampere/backend.py
@@ -19,14 +19,37 @@ from __future__ import annotations
 
 from vllm.logger import init_logger
 from vllm.platforms.interface import DeviceCapability
-from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionBackend,
+    FlashAttentionMetadataBuilder,
+)
 
 from .impl import FlashAmpereImpl
 
 logger = init_logger(__name__)
 
 
+class FlashAmpereMetadataBuilder(FlashAttentionMetadataBuilder):
+    """FA builder + the CPU metadata twins the famp legs need for sync-free dispatch.
+
+    FlashAttentionMetadata carries only GPU query_start_loc/seq_lens; the legs used to
+    .tolist() them = 2 device syncs per LAYER per step (paid even when the mixed-batch
+    decline then sank the call to stock FA). CommonAttentionMetadata already holds the CPU
+    twins, but the impl never sees it — attach them here (once per STEP, no extra sync:
+    query_start_loc_cpu is a builder input; seq_lens_cpu a lazily-cached property)."""
+
+    def build(self, common_prefix_len, common_attn_metadata, fast_build: bool = False):
+        md = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        md.query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+        md.seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        return md
+
+
 class FlashAmpereBackend(FlashAttentionBackend):
+    @staticmethod
+    def get_builder_cls() -> type[FlashAmpereMetadataBuilder]:
+        return FlashAmpereMetadataBuilder
+
     @staticmethod
     def get_name() -> str:
         # Registered into the CUSTOM slot; AttentionBackendEnum["CUSTOM"] resolves cleanly.

--- a/flashampere/backend.py
+++ b/flashampere/backend.py
@@ -17,6 +17,8 @@ change attention for every model.
 """
 from __future__ import annotations
 
+import torch
+
 from vllm.logger import init_logger
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends.flash_attn import (
@@ -43,6 +45,68 @@ class FlashAmpereMetadataBuilder(FlashAttentionMetadataBuilder):
         md.query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         md.seq_lens_cpu = common_attn_metadata.seq_lens_cpu
         return md
+
+    def __init__(self, kv_cache_spec, layer_names, vllm_config, device):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self._prewarm_xqa_verify(vllm_config, device)
+
+    def _prewarm_xqa_verify(self, vllm_config, device) -> None:
+        # 0.25.1 warmup dummy runs are non-spec (draft=0 -> Phase.DECODE), so the first
+        # VERIFY-shaped call per shape lands inside FULL-graph capture, where xqa_verify
+        # must decline (no JIT/alloc while capturing) -> base-FA gets baked into every
+        # captured graph and the leg never fires. Pre-build the module + per-batch
+        # buffers here: builder init runs eagerly in each worker before capture and has
+        # the full config. No-op unless the leg is enabled and spec-decode is on.
+        try:
+            from .impl import _caps
+            from . import xqa_verify as _xv
+
+            spec = vllm_config.speculative_config
+            if (
+                not _caps().enabled("xqa_verify")
+                or spec is None
+                or not spec.num_speculative_tokens
+                or not self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+            ):
+                return
+            q_seq_len = 1 + spec.num_speculative_tokens
+            head_dim = self.headdim
+            q_dtype = self.model_config.dtype
+            if not _xv.is_supported_head_dim(head_dim) or q_dtype not in (
+                torch.float16,
+                torch.bfloat16,
+            ):
+                return
+            # Mirror the dispatcher's uniform-decode req ladder:
+            # num_reqs = min(num_tokens_padded // q_seq_len, max_num_seqs).
+            max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+            sizes = self.compilation_config.cudagraph_capture_sizes or []
+            num_reqs_list = sorted(
+                {
+                    min(s // q_seq_len, max_num_seqs)
+                    for s in sizes
+                    if s >= q_seq_len and s % q_seq_len == 0
+                }
+            )
+            if not num_reqs_list:
+                return
+            _xv.prewarm(
+                q_dtype=q_dtype,
+                kv_dtype=self.kv_cache_dtype,
+                page_size=self.block_size,
+                head_dim=head_dim,
+                grp=self.num_heads_q // self.num_heads_kv,
+                q_seq_len=q_seq_len,
+                num_reqs_list=num_reqs_list,
+                Hkv=self.num_heads_kv,
+                device=device,
+            )
+        except Exception:
+            logger.warning(
+                "flashampere: xqa_verify prewarm failed; the VERIFY leg will decline "
+                "at capture and spec-verify will run on base FA",
+                exc_info=True,
+            )
 
 
 class FlashAmpereBackend(FlashAttentionBackend):

--- a/flashampere/dispatch.py
+++ b/flashampere/dispatch.py
@@ -21,8 +21,8 @@ from typing import NamedTuple
 
 # Head dims each prefill leg accelerates. fp16-PV (fp16pv fp16-served / bf16cvt bf16-served) targets
 # the Qwen3.x hd256 full-attn layers; SageAttn targets the smaller dense hd's. Extend to widen.
-FP16PV_HEADS: tuple[int, ...] = (256, 512)  # fp16-served (q dtype == fp16); 512 = Gemma4 full-attn
-BF16CVT_HEADS: tuple[int, ...] = (256, 512)  # bf16-served (runtime upcast to fp16); 512 = Gemma4 full-attn
+FP16PV_HEADS: tuple[int, ...] = (128, 256, 512)  # fp16-served; 512=Gemma4; 128=BATCH path only
+BF16CVT_HEADS: tuple[int, ...] = (128, 256, 512)  # bf16-served (upcast); hd128 legacy leg declines
 XQA_VERIFY_HEADS: tuple[int, ...] = (64, 128, 256)  # MTP spec-verify (XQA headElems 64/128/256)
 SAGE_HEADS: tuple[int, ...] = (64, 96, 128)
 

--- a/flashampere/impl.py
+++ b/flashampere/impl.py
@@ -68,9 +68,12 @@ class FlashAmpereImpl(FlashAttentionImpl):
         try:
             from vllm.config import get_current_vllm_config
 
-            self._fc_max_num_seqs = get_current_vllm_config().scheduler_config.max_num_seqs
+            _sc = get_current_vllm_config().scheduler_config
+            self._fc_max_num_seqs = _sc.max_num_seqs
+            self._fc_max_num_batched_tokens = _sc.max_num_batched_tokens
         except Exception:
             self._fc_max_num_seqs = None
+            self._fc_max_num_batched_tokens = None
 
     @staticmethod
     def _nonplain_metadata(m) -> bool:

--- a/flashampere/impl.py
+++ b/flashampere/impl.py
@@ -7,6 +7,8 @@ capability.py. The base FA forward already carries the MTP-verify fwd_kvcache fi
 (VLLM_FA2_KVCACHE_VERIFY), so VERIFY and DECODE sink to it unchanged."""
 from __future__ import annotations
 
+import os
+
 import torch
 
 from vllm.logger import init_logger
@@ -191,6 +193,13 @@ class FlashAmpereImpl(FlashAttentionImpl):
         # ever fires defensively (incl. spec-decode capture, where verify already sank above).
         capturing = torch.cuda.is_current_stream_capturing()
 
+        if os.environ.get("FAMP_DEBUG_DISPATCH"):
+            _ent = [e.name for e in resolve(key_t)]
+            logger.info(
+                "famp-debug phase=%s hd=%s qdt=%s entries=%s enabled=%s",
+                phase, self.head_size, query.dtype, _ent,
+                [n for n in _ent if self._caps.enabled(n)],
+            )
         for entry in resolve(key_t):
             if capturing and not entry.capture_safe:
                 continue

--- a/flashampere/impl.py
+++ b/flashampere/impl.py
@@ -82,11 +82,18 @@ class FlashAmpereImpl(FlashAttentionImpl):
           - sliding_window on the METADATA (batch-level override of the impl's static window),
           - rswa_prefix_lens / rswa_window / rswa_window_tensor (Reference-SWA masking).
         Any of these set/non-default -> sink to stock FA (bit-faithful; FA implements them).
-        getattr defaults keep this a no-op on 0.23-era metadata (fields absent)."""
+        getattr defaults keep this a no-op on 0.23-era metadata (fields absent).
+        NB: 0.25.1 populates sliding_window=(-1, -1) unconditionally as the no-window sentinel —
+        normalize it before the check, else every batch reads nonplain and the legs go dead."""
+        sw = getattr(m, "sliding_window", None)
+        if isinstance(sw, (tuple, list)):
+            sw = None if tuple(sw) == (-1, -1) else sw
+        elif sw == -1:
+            sw = None
         return (
             isinstance(getattr(m, "causal", True), torch.Tensor)
             or getattr(m, "mm_prefix_range_tensor", None) is not None
-            or getattr(m, "sliding_window", None) is not None
+            or sw is not None
             or getattr(m, "rswa_prefix_lens", None) is not None
             or getattr(m, "rswa_window", None) is not None
             or getattr(m, "rswa_window_tensor", None) is not None

--- a/flashampere/kernels.py
+++ b/flashampere/kernels.py
@@ -49,6 +49,16 @@ _FP16_MAX = 65504.0
 # Per-PROCESS one-time "fired here" latch -> a per-rank log line under TP/PP (separate procs).
 _FIRED_LOGGED = False
 
+# Batch-prefill fast path: skip the defensive out.zero_() before paged_run (FI's run() inits out
+# with torch.zeros; the fa2 kernel/merge writes every row, so the zero is believed redundant —
+# A/B knob until validated, then default flips).
+_BP_ZERO = os.environ.get("FAMP_BP_NOZERO", "0") not in ("1", "true", "True")
+
+# Batch-prefill engagement floor: steps with fewer total query tokens than this (prefix-cache
+# hits, tiny tail chunks) stay on stock FA — the batch path's per-step plan() costs more than
+# its kernel win on few-ms ops. Measured crossover O(hundreds) of tokens on RTX 3090.
+_BP_MIN_TOKENS = int(os.environ.get("FAMP_BP_MIN_TOKENS", "512"))
+
 is_quantized_kv_cache = _fa.is_quantized_kv_cache
 
 
@@ -113,18 +123,19 @@ class _BatchPrefillState:
         self.kvdtype = kv_cache.dtype
         self.ws = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=dev)
         self.wrapper = None
-        self._planned_meta_id: int | None = None
-        # Scatter-compact constants for the sync-free indices flatten (same trick as
-        # _Hd512DecodeState._build_meta: fixed-size dest + trash slot, sliced by a CPU-known total).
-        self._col = None
-        self._buf = None
-        # paged_run fast-path template (recorded per step on the first layer): the FI wrapper's
-        # per-layer python (arg assembly + checks, ~200us/layer) does not hide under short kernels
-        # and was the residual e2e loss. Layers 2..N swap q/k/v/out into the recorded args by
-        # position and call module.paged_run directly (one ffi call).
+        # Scatter-compact machinery for the sync-free indices flatten (sized lazily; mb =
+        # block_table columns is unknown until the first step).
+        self._col = self._scatter = None
+        # paged_run template, recorded ONCE EVER: plan() hands the wrapper NEW plan-input tensors
+        # + plan_info each step -> plan_step refreshes those recorded slots; run_fast swaps only
+        # q/k/v/out per layer. NB non-graph wrapper on purpose: cuda-graph mode schedules every
+        # step at the locked worst-case row ceiling (args[6]=max_total_num_rows) -> padded grids,
+        # measured e2e loss; eager prefill wants exact per-step grids.
         self._tmpl: list | None = None
         self._kw: dict | None = None
-        self._pos: tuple[int, int, int, int] | None = None
+        self._pos: tuple[int, int, int, int] | None = None       # q, k, v, out arg slots
+        self._plan_slots: tuple[tuple[int, str], ...] | None = None  # (slot, wrapper attr)
+        self._planned: tuple | None = None
 
     def _get_wrapper(self):
         if self.wrapper is None:
@@ -137,62 +148,77 @@ class _BatchPrefillState:
         return self.wrapper
 
     def plan_step(self, m, qsl_cpu, sl_cpu):
-        """Plan once per step (id(m) = per-step metadata identity); later layers reuse."""
-        w = self._get_wrapper()
-        if self._planned_meta_id == id(m):
-            return w
-        self._tmpl = None  # new step -> re-record the paged_run arg template on the first layer
-        ps = self.ps
-        sl = sl_cpu.to(torch.int32)
-        npg_cpu = (sl + ps - 1) // ps
-        kv_indptr_cpu = torch.zeros(sl.numel() + 1, dtype=torch.int32)
-        kv_indptr_cpu[1:] = torch.cumsum(npg_cpu, 0).to(torch.int32)
-        klp_cpu = (sl - (npg_cpu - 1) * ps).to(torch.int32)
-        # Flatten the first npg[i] block ids of each block_table row WITHOUT a device sync:
-        # scatter valid entries to compacted positions in a fixed-size buffer (+1 trash slot),
-        # then slice by the CPU-known total page count.
-        bt = m.block_table
-        B, mb = bt.shape[0], bt.shape[1]
-        dev = bt.device
-        if self._col is None or self._col.numel() < B * mb:
-            self._col = torch.arange(mb, device=dev).unsqueeze(0).expand(B, -1).reshape(-1)
-            self._buf = torch.zeros(B * mb + 1, dtype=torch.int32, device=dev)
-        npg_dev = (m.seq_lens + ps - 1) // ps                                  # [B] GPU
-        col = self._col[: B * mb]
-        valid = col < npg_dev.unsqueeze(1).expand(-1, mb).reshape(-1)
-        out_pos = torch.cumsum(valid.to(torch.int64), 0) - 1
-        dest = torch.where(valid, out_pos, torch.full_like(out_pos, self._buf.numel() - 1))
-        self._buf.zero_()
-        self._buf.scatter_(0, dest, bt.reshape(-1).to(torch.int32))
-        total = int(kv_indptr_cpu[-1])
-        indices = self._buf[:total]
-        w.plan(
-            qsl_cpu.to(torch.int32), kv_indptr_cpu, indices, klp_cpu,
-            self.Hq, self.Hkv, self.D, ps, causal=True, sm_scale=self.sm,
-            window_left=-1, q_data_type=torch.float16, kv_data_type=self.kvdtype,
-        )
-        self._planned_meta_id = id(m)
+        """Plan once per step; refresh the template's plan-dependent slots. Any plan shortfall
+        declines the step to stock FA instead of raising."""
+        B = sl_cpu.numel()
+        # id(m) alone is unsafe (CPython reuses freed addresses across steps) -> add a cheap
+        # content fingerprint from the CPU twins (no device sync).
+        key = (id(m), B, int(qsl_cpu[-1]), int(sl_cpu.sum()))
+        if self._planned == key:
+            return self.wrapper
+        try:
+            w = self._get_wrapper()
+            ps = self.ps
+            sl = sl_cpu.to(torch.int32)
+            npg_cpu = (sl + ps - 1) // ps
+            kv_indptr_cpu = torch.zeros(B + 1, dtype=torch.int32)
+            kv_indptr_cpu[1:] = torch.cumsum(npg_cpu, 0).to(torch.int32)
+            klp_cpu = (sl - (npg_cpu - 1) * ps).to(torch.int32)
+            # Flatten the first npg[i] block ids of each block_table row WITHOUT a device sync:
+            # scatter valid entries to compacted positions (+1 trash slot), slice by the
+            # CPU-known total page count.
+            bt = m.block_table
+            mb = bt.shape[1]
+            dev = bt.device
+            if self._col is None or self._col.numel() < B * mb:
+                n = max(B, 8)
+                self._col = torch.arange(mb, device=dev).repeat(n)
+                self._scatter = torch.zeros(n * mb + 1, dtype=torch.int32, device=dev)
+            npg_dev = (m.seq_lens + ps - 1) // ps                              # [B] GPU
+            col = self._col[: B * mb]
+            valid = col < npg_dev.unsqueeze(1).expand(-1, mb).reshape(-1)
+            out_pos = torch.cumsum(valid.to(torch.int64), 0) - 1
+            dest = torch.where(valid, out_pos, torch.full_like(out_pos, self._scatter.numel() - 1))
+            self._scatter.zero_()
+            self._scatter.scatter_(0, dest, bt.reshape(-1).to(torch.int32))
+            total = int(kv_indptr_cpu[-1])
+            w.plan(
+                qsl_cpu.to(torch.int32), kv_indptr_cpu, self._scatter[:total], klp_cpu,
+                self.Hq, self.Hkv, self.D, ps, causal=True, sm_scale=self.sm,
+                window_left=-1, q_data_type=torch.float16, kv_data_type=self.kvdtype,
+            )
+        except KernelDecline:
+            raise
+        except Exception as e:
+            logger.warning_once("famp batch_prefill plan declined: %s", e)
+            raise KernelDecline from e
+        if self._tmpl is not None and self._plan_slots is not None:
+            t = self._tmpl
+            for i, attr in self._plan_slots:
+                t[i] = getattr(w, attr)
+        self._planned = key
         return w
 
     def run_fast(self, w, q, kv_cache, out):
-        """First layer of a step: full wrapper.run with a paged_run recorder (correct-by-
-        construction args, whatever the FI patch level passes). Later layers: swap the four
-        per-layer tensors into the recorded template by identity/data_ptr and call the module's
-        paged_run directly. Falls back to wrapper.run whenever positions can't be located."""
+        """Record ONCE EVER: the first call goes through the full wrapper.run under a paged_run
+        recorder (args correct-by-construction for whatever the FI patch level passes). Every
+        subsequent layer of every step is one direct module.paged_run ffi call: plan-dependent
+        slots are refreshed in plan_step, q/k/v/out swapped here by recorded position."""
         mod = w._cached_module
         kc, vc = kv_cache.unbind(1)
         if self._tmpl is not None and self._pos is not None:
             iq, ik, iv, io = self._pos
             t = self._tmpl
             t[iq], t[ik], t[iv], t[io] = q, kc, vc, out
-            out.zero_()  # match FI's torch.zeros out-init (split-KV merge contract)
+            if _BP_ZERO:
+                out.zero_()  # FI's torch.zeros out-init; FAMP_BP_NOZERO=1 skips it (A/B knob)
             mod.paged_run(*t, **self._kw)
             return out
         rec: dict = {}
         orig = mod.paged_run
-        def _recorder(*a, **kw):
-            rec["a"], rec["kw"] = list(a), dict(kw)
-            return orig(*a, **kw)
+        def _recorder(*args_, **kw_):
+            rec["a"], rec["kw"] = list(args_), dict(kw_)
+            return orig(*args_, **kw_)
         mod.paged_run = _recorder
         try:
             out.zero_()
@@ -210,8 +236,22 @@ class _BatchPrefillState:
                         return i
                 return -1
             iq, ik, iv, io = _find(q), _find(kc), _find(vc), _find(out)
-            if -1 not in (iq, ik, iv, io):
-                self._tmpl, self._kw, self._pos = a, rec.get("kw") or {}, (iq, ik, iv, io)
+            # Slots the wrapper REPLACES on every plan(): collect ALL occurrences per attr (the
+            # extended fa2 tail repeats qo/kv indptr) so each step's refresh covers every copy.
+            slots: list[tuple[int, str]] = []
+            ok = True
+            for attr in ("_plan_info", "_qo_indptr_buf", "_paged_kv_indptr_buf",
+                         "_paged_kv_indices_buf", "_paged_kv_last_page_len_buf"):
+                obj = getattr(w, attr, None)
+                found = [j for j, v in enumerate(a) if v is obj] if obj is not None else []
+                if not found:
+                    ok = False
+                    break
+                slots.extend((j, attr) for j in found)
+            if ok and -1 not in (iq, ik, iv, io):
+                self._tmpl, self._kw = a, rec.get("kw") or {}
+                self._pos = (iq, ik, iv, io)
+                self._plan_slots = tuple(slots)
         return o
 
 
@@ -287,6 +327,9 @@ def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: 
         and _sl_cpu is not None
         and qlens
         and min(qlens) > 1
+        # Small-q steps (prefix-cache hits, tail chunks) are a few-ms op where the per-step
+        # plan() tax exceeds the kernel win — leave those to stock FA. Full chunks engage.
+        and int(_qsl_cpu[-1]) >= _BP_MIN_TOKENS
     ):
         return _batch_prefill_run(
             impl, layer, query, key, value, kv_cache, m, output, _qsl_cpu, _sl_cpu, leg

--- a/flashampere/kernels.py
+++ b/flashampere/kernels.py
@@ -118,6 +118,13 @@ class _BatchPrefillState:
         # _Hd512DecodeState._build_meta: fixed-size dest + trash slot, sliced by a CPU-known total).
         self._col = None
         self._buf = None
+        # paged_run fast-path template (recorded per step on the first layer): the FI wrapper's
+        # per-layer python (arg assembly + checks, ~200us/layer) does not hide under short kernels
+        # and was the residual e2e loss. Layers 2..N swap q/k/v/out into the recorded args by
+        # position and call module.paged_run directly (one ffi call).
+        self._tmpl: list | None = None
+        self._kw: dict | None = None
+        self._pos: tuple[int, int, int, int] | None = None
 
     def _get_wrapper(self):
         if self.wrapper is None:
@@ -134,6 +141,7 @@ class _BatchPrefillState:
         w = self._get_wrapper()
         if self._planned_meta_id == id(m):
             return w
+        self._tmpl = None  # new step -> re-record the paged_run arg template on the first layer
         ps = self.ps
         sl = sl_cpu.to(torch.int32)
         npg_cpu = (sl + ps - 1) // ps
@@ -166,6 +174,46 @@ class _BatchPrefillState:
         self._planned_meta_id = id(m)
         return w
 
+    def run_fast(self, w, q, kv_cache, out):
+        """First layer of a step: full wrapper.run with a paged_run recorder (correct-by-
+        construction args, whatever the FI patch level passes). Later layers: swap the four
+        per-layer tensors into the recorded template by identity/data_ptr and call the module's
+        paged_run directly. Falls back to wrapper.run whenever positions can't be located."""
+        mod = w._cached_module
+        kc, vc = kv_cache.unbind(1)
+        if self._tmpl is not None and self._pos is not None:
+            iq, ik, iv, io = self._pos
+            t = self._tmpl
+            t[iq], t[ik], t[iv], t[io] = q, kc, vc, out
+            out.zero_()  # match FI's torch.zeros out-init (split-KV merge contract)
+            mod.paged_run(*t, **self._kw)
+            return out
+        rec: dict = {}
+        orig = mod.paged_run
+        def _recorder(*a, **kw):
+            rec["a"], rec["kw"] = list(a), dict(kw)
+            return orig(*a, **kw)
+        mod.paged_run = _recorder
+        try:
+            out.zero_()
+            o = w.run(q, kv_cache, out=out)
+        finally:
+            mod.paged_run = orig
+        a = rec.get("a")
+        if a is not None:
+            def _find(x):
+                for i, v in enumerate(a):
+                    if v is x or (
+                        isinstance(v, torch.Tensor) and isinstance(x, torch.Tensor)
+                        and v.data_ptr() == x.data_ptr() and v.shape == x.shape
+                    ):
+                        return i
+                return -1
+            iq, ik, iv, io = _find(q), _find(kc), _find(vc), _find(out)
+            if -1 not in (iq, ik, iv, io):
+                self._tmpl, self._kw, self._pos = a, rec.get("kw") or {}, (iq, ik, iv, io)
+        return o
+
 
 _BP_STATES: dict[tuple, _BatchPrefillState] = {}
 
@@ -182,8 +230,7 @@ def _batch_prefill_run(impl, layer, query, key, value, kv_cache, m, output, qsl_
         st = _BP_STATES[skey] = _BatchPrefillState(impl, kv_cache, query.device)
     w = st.plan_step(m, qsl_cpu, sl_cpu)
     q = query.reshape(-1, impl.num_heads, impl.head_size)
-    o = w.run(q, kv_cache)
-    output.copy_(o.reshape(output.shape))
+    st.run_fast(w, q, kv_cache, output.reshape(q.shape))
     FIRE["calls"] += 1
     FIRE["batch"] += 1
     _log_fired_once("batch_prefill", int(q.shape[0]), -1, impl.head_size)

--- a/flashampere/kernels.py
+++ b/flashampere/kernels.py
@@ -37,7 +37,7 @@ except Exception as e:  # pragma: no cover - import guard
     logger.warning("flashinfer not importable (%s); flashampere prefill legs delegate to FA.", e)
 
 # Fire counter (read by the validation harness): totals + per-leg breakdown.
-FIRE = {"calls": 0, "seqs": 0, "fresh": 0, "cached": 0, "fp16pv": 0, "bf16cvt": 0}
+FIRE = {"calls": 0, "seqs": 0, "fresh": 0, "cached": 0, "fp16pv": 0, "bf16cvt": 0, "batch": 0}
 
 # bf16->fp16 upcast is lossless for attention inputs in the fp16 NORMAL range (fp16 carries 10
 # mantissa bits vs bf16's 7), but bf16's wider exponent can hold values above fp16 max (65504).
@@ -99,6 +99,97 @@ def _log_fired_once(leg: str, Lq: int, ctx: int, D: int) -> None:
     )
 
 
+class _BatchPrefillState:
+    """De-taxed PREFILL: ONE batched paged-KV BatchPrefill run per layer on famp's vendored
+    fp16-PV kernel (wrapper._jit_module injection), planned ONCE per step from the CPU metadata
+    twins — no per-request loop, no paged->contiguous gather, no KV cast, zero device syncs.
+    Phase-1 scope: fp16-served only (FA_PV16 needs DTypeQ==half and an fp16 KV cache); eager
+    (prefill is not captured). One state per (layer head-config, page size)."""
+
+    def __init__(self, impl, kv_cache, dev):
+        self.Hq, self.Hkv, self.D = impl.num_heads, impl.num_kv_heads, impl.head_size
+        self.sm = impl.scale
+        self.ps = kv_cache.shape[2]
+        self.kvdtype = kv_cache.dtype
+        self.ws = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=dev)
+        self.wrapper = None
+        self._planned_meta_id: int | None = None
+        # Scatter-compact constants for the sync-free indices flatten (same trick as
+        # _Hd512DecodeState._build_meta: fixed-size dest + trash slot, sliced by a CPU-known total).
+        self._col = None
+        self._buf = None
+
+    def _get_wrapper(self):
+        if self.wrapper is None:
+            from .prefill._jit_batch_prefill import install_famp_batch_prefill
+
+            # By-key spec shim: plan() resolves the standard module path to famp's vendored
+            # fp16-PV kernel for exactly this config; other keys stay stock.
+            install_famp_batch_prefill(torch.float16, self.kvdtype, torch.float16, self.D)
+            self.wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(self.ws, "NHD")
+        return self.wrapper
+
+    def plan_step(self, m, qsl_cpu, sl_cpu):
+        """Plan once per step (id(m) = per-step metadata identity); later layers reuse."""
+        w = self._get_wrapper()
+        if self._planned_meta_id == id(m):
+            return w
+        ps = self.ps
+        sl = sl_cpu.to(torch.int32)
+        npg_cpu = (sl + ps - 1) // ps
+        kv_indptr_cpu = torch.zeros(sl.numel() + 1, dtype=torch.int32)
+        kv_indptr_cpu[1:] = torch.cumsum(npg_cpu, 0).to(torch.int32)
+        klp_cpu = (sl - (npg_cpu - 1) * ps).to(torch.int32)
+        # Flatten the first npg[i] block ids of each block_table row WITHOUT a device sync:
+        # scatter valid entries to compacted positions in a fixed-size buffer (+1 trash slot),
+        # then slice by the CPU-known total page count.
+        bt = m.block_table
+        B, mb = bt.shape[0], bt.shape[1]
+        dev = bt.device
+        if self._col is None or self._col.numel() < B * mb:
+            self._col = torch.arange(mb, device=dev).unsqueeze(0).expand(B, -1).reshape(-1)
+            self._buf = torch.zeros(B * mb + 1, dtype=torch.int32, device=dev)
+        npg_dev = (m.seq_lens + ps - 1) // ps                                  # [B] GPU
+        col = self._col[: B * mb]
+        valid = col < npg_dev.unsqueeze(1).expand(-1, mb).reshape(-1)
+        out_pos = torch.cumsum(valid.to(torch.int64), 0) - 1
+        dest = torch.where(valid, out_pos, torch.full_like(out_pos, self._buf.numel() - 1))
+        self._buf.zero_()
+        self._buf.scatter_(0, dest, bt.reshape(-1).to(torch.int32))
+        total = int(kv_indptr_cpu[-1])
+        indices = self._buf[:total]
+        w.plan(
+            qsl_cpu.to(torch.int32), kv_indptr_cpu, indices, klp_cpu,
+            self.Hq, self.Hkv, self.D, ps, causal=True, sm_scale=self.sm,
+            window_left=-1, q_data_type=torch.float16, kv_data_type=self.kvdtype,
+        )
+        self._planned_meta_id = id(m)
+        return w
+
+
+_BP_STATES: dict[tuple, _BatchPrefillState] = {}
+
+
+def _batch_prefill_run(impl, layer, query, key, value, kv_cache, m, output, qsl_cpu, sl_cpu, leg):
+    key_cache, value_cache = kv_cache.unbind(1)
+    _reshape_and_cache_flash(
+        key, value, key_cache, value_cache,
+        m.slot_mapping, impl.kv_cache_dtype, layer._k_scale, layer._v_scale,
+    )
+    skey = (impl.num_heads, impl.num_kv_heads, impl.head_size, kv_cache.dtype, kv_cache.shape[2])
+    st = _BP_STATES.get(skey)
+    if st is None:
+        st = _BP_STATES[skey] = _BatchPrefillState(impl, kv_cache, query.device)
+    w = st.plan_step(m, qsl_cpu, sl_cpu)
+    q = query.reshape(-1, impl.num_heads, impl.head_size)
+    o = w.run(q, kv_cache)
+    output.copy_(o.reshape(output.shape))
+    FIRE["calls"] += 1
+    FIRE["batch"] += 1
+    _log_fired_once("batch_prefill", int(q.shape[0]), -1, impl.head_size)
+    return output
+
+
 def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: str = "fp16pv"):
     """fp16-PV prefill — gather/loop + fp16 FlashInfer with use_fp16_pv_reduction. Casts Q/K/V to fp16
     and runs FlashInfer with use_fp16_pv_reduction (DTypeProb=half). Serves BOTH:
@@ -114,10 +205,18 @@ def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: 
     if not _HAS_FI:
         raise KernelDecline
     guard_fp16 = leg == "bf16cvt"  # bf16 source: range-check Q/K/V before upcast (else inf on cast)
-    cu_list = m.query_start_loc.tolist()
+    # CPU twins attached by FlashAmpereMetadataBuilder -> zero device syncs here (and none paid
+    # when the mixed-batch check below declines). Device-tensor .tolist() is the legacy fallback.
+    _qsl_cpu = getattr(m, "query_start_loc_cpu", None)
+    _sl_cpu = getattr(m, "seq_lens_cpu", None)
+    if _qsl_cpu is not None and _sl_cpu is not None:
+        cu_list = _qsl_cpu.tolist()
+        seq_lens_cpu = _sl_cpu.tolist()
+    else:
+        cu_list = m.query_start_loc.tolist()
+        seq_lens_cpu = m.seq_lens.tolist()
     n_req = len(cu_list) - 1
     qlens = [int(cu_list[i + 1] - cu_list[i]) for i in range(n_req)]
-    seq_lens_cpu = m.seq_lens.tolist()
     # A decode row (q=1, ctx>0) mixed into a prefill batch (continuous batching) is the one shape FI
     # single_prefill can't do (q_len=1 -> max_mma_kv=0). For hd<=256 we DECLINE so stock FA handles
     # the whole mixed batch optimally. For hd>256 (Gemma4 512) FA has NO path (head_size>256 reject),
@@ -126,6 +225,29 @@ def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: 
         for i in range(n_req):
             if qlens[i] == 1 and seq_lens_cpu[i] > 1:
                 raise KernelDecline
+
+    # De-taxed batched path (opt-in VLLM_FAMP_BATCH_PREFILL=1): one paged BatchPrefill run on the
+    # vendored fp16-PV kernel — no gather/loop/casts. Phase-1 scope: fp16-served (FA_PV16 needs
+    # half Q AND half KV cache), hd<=256, CPU metadata present, no q_len=1 rows (paged q-tile floor).
+    batch_on = os.environ.get("VLLM_FAMP_BATCH_PREFILL", "0") in ("1", "true", "True")
+    if (
+        batch_on
+        and leg == "fp16pv"
+        and impl.head_size <= 256
+        and query.dtype == torch.float16
+        and kv_cache.dtype == torch.float16
+        and _qsl_cpu is not None
+        and _sl_cpu is not None
+        and qlens
+        and min(qlens) > 1
+    ):
+        return _batch_prefill_run(
+            impl, layer, query, key, value, kv_cache, m, output, _qsl_cpu, _sl_cpu, leg
+        )
+    # hd<256 through the LEGACY per-request leg measured e2e-NEGATIVE (leg tax > kernel win,
+    # −14..−48% TTFT on Qwen3-8B) — only the de-taxed batch path above may take those heads.
+    if impl.head_size < 256:
+        raise KernelDecline
 
     key_cache, value_cache = kv_cache.unbind(1)
     _reshape_and_cache_flash(
@@ -162,8 +284,17 @@ def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: 
         # (NaN fails the <=), so the leg never forwards a non-finite tensor into the cubin. Never
         # fires for real O(1-50) post-norm activations; pure insurance.
         if guard_fp16:
-            mx = max(float(q_src.abs().amax()), float(k_src.abs().amax()), float(v_src.abs().amax()))
-            if not (mx <= _FP16_MAX):
+            # One fused inf-norm per operand (no materialized .abs()) + a SINGLE device sync for
+            # all three (was 3 abs+amax kernels + 3 .item() syncs = the largest leg overhead,
+            # 41-46% measured). NaN still fails the <= (vector_norm propagates it).
+            mx = torch.maximum(
+                torch.maximum(
+                    torch.linalg.vector_norm(q_src, ord=float("inf")),
+                    torch.linalg.vector_norm(k_src, ord=float("inf")),
+                ),
+                torch.linalg.vector_norm(v_src, ord=float("inf")),
+            )
+            if not (float(mx) <= _FP16_MAX):
                 raise KernelDecline
         q = q_src.to(torch.float16)
         k = k_src.to(torch.float16)

--- a/flashampere/prefill/_jit_batch_prefill.py
+++ b/flashampere/prefill/_jit_batch_prefill.py
@@ -1,0 +1,67 @@
+"""famp owned FA2 BATCH paged prefill (fp16-PV) — the de-taxed prefill path.
+
+Injection point: flashinfer's standard batch-prefill flow is
+    wrapper.plan() -> get_batch_prefill_module(backend, *args)   [functools.cache]
+                   -> gen_batch_prefill_module(backend, *args).build_and_load()
+We shim `gen_batch_prefill_module` in flashinfer.prefill's namespace with a BY-EXACT-KEY
+override: famp's config keys resolve to a JitSpec rebuilt under famp's name with the VENDORED
+prefill.cuh first on the include path (FA_PV16 fp16-PV epilogue + the sm86 tile heuristic);
+every other key defers to stock flashinfer (e.g. the hd512 bf16 decode wrapper). This keeps the
+wrapper's standard plan/run ABI (the `_jit_module` ctor path expects the CUSTOMIZE codegen ABI —
+16-arg plan — and is NOT usable for a standard-ABI kernel; measured mismatch 19-vs-16).
+Install BEFORE the first plan() for the key (get_batch_prefill_module caches per key)."""
+import pathlib
+
+import torch
+from flashinfer.jit.attention.modules import gen_batch_prefill_module as _stock_gen
+from flashinfer.jit.core import JitSpec, gen_jit_spec
+
+_INC = pathlib.Path(__file__).parent / "include"  # vendored flashinfer/attention/prefill.cuh
+
+
+def _famp_spec(backend, *args, use_fp16_pv: bool = True) -> JitSpec:
+    base = _stock_gen(backend, *args)
+    extra_cflags = ["-DFA_USE_FP16_PV=1"] if use_fp16_pv else []
+    inc = [str(_INC)] + [str(p) for p in (base.extra_include_dirs or [])]
+    return gen_jit_spec(
+        "famp_" + base.name,                       # unique name -> fresh build dir, our settings
+        base.sources,                              # flashinfer's generated binding (ABI match)
+        extra_cflags=base.extra_cflags,
+        extra_cuda_cflags=list(base.extra_cuda_cflags) + extra_cflags,
+        extra_ldflags=base.extra_ldflags,
+        extra_include_paths=inc,                   # OUR prefill.cuh first
+        needs_device_linking=base.needs_device_linking,
+    )
+
+
+def install_famp_batch_prefill(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    head_dim: int,
+    use_fp16_pv: bool = True,
+) -> None:
+    """Idempotently route this exact batch-prefill config to the famp spec (in-process only)."""
+    import flashinfer.prefill as fip
+
+    key = (
+        "fa2", dtype_q, dtype_kv, dtype_o, torch.int32, head_dim, head_dim,
+        0,      # PosEncodingMode NONE
+        False,  # use_sliding_window
+        False,  # use_logits_soft_cap
+        False,  # use_fp16_qk_reduction
+    )
+    cur = fip.gen_batch_prefill_module
+    if not getattr(cur, "_famp_shim", False):
+        overrides: dict[tuple, JitSpec] = {}
+
+        def _shim(backend, *args):
+            spec = overrides.get((backend, *args))
+            return spec if spec is not None else _stock_gen(backend, *args)
+
+        _shim._famp_shim = True
+        _shim._famp_overrides = overrides
+        fip.gen_batch_prefill_module = _shim
+        cur = _shim
+    if key not in cur._famp_overrides:
+        cur._famp_overrides[key] = _famp_spec(*key, use_fp16_pv=use_fp16_pv)

--- a/flashampere/prefill/include/flashinfer/attention/prefill.cuh
+++ b/flashampere/prefill/include/flashinfer/attention/prefill.cuh
@@ -25,6 +25,8 @@
 #endif
 #include <cuda_runtime.h>
 
+#include <cstdlib>
+
 #include <flashinfer/cp_async.cuh>
 #include <flashinfer/fastdiv.cuh>
 #ifdef FP16_QK_REDUCTION_SUPPORTED
@@ -2162,6 +2164,21 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
   constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
   int64_t packed_qo_len = qo_len * group_size;
   uint32_t cta_tile_q = FA2DetermineCtaTileQ(packed_qo_len, HEAD_DIM_VO);
+  // famp: on GA10x (sm86, 99KB smem/CTA cap) the 64-row Q tile beats 128 for short/mid prefill —
+  // NUM_MMA_Q=1 shortens the per-fragment MMA dependency chain and doubles CTA-level parallelism.
+  // Measured on RTX 3090 hd128: +6..23% for packed_qo_len<=16k, ~0..-2% above (crossover 16k-32k),
+  // so switch below the guaranteed-win zone only. hd256 unmeasured -> untouched.
+  // FAMP_CTA_TILE_Q overrides for experiments.
+  if (cta_tile_q > 64 && HEAD_DIM_VO == 128 && packed_qo_len <= 16384) {
+    int _dev = 0, _major = 0, _minor = 0;
+    FLASHINFER_CUDA_CALL(cudaGetDevice(&_dev));
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&_major, cudaDevAttrComputeCapabilityMajor, _dev));
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&_minor, cudaDevAttrComputeCapabilityMinor, _dev));
+    if (_major == 8 && _minor >= 6) cta_tile_q = 64;
+  }
+  if (const char* _ftq = std::getenv("FAMP_CTA_TILE_Q")) {
+    cta_tile_q = static_cast<uint32_t>(std::atoi(_ftq));
+  }
 
   DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
     constexpr uint32_t NUM_WARPS_Q = get_num_warps_q(CTA_TILE_Q);

--- a/flashampere/xqa_verify.py
+++ b/flashampere/xqa_verify.py
@@ -99,6 +99,62 @@ def is_supported_head_dim(head_dim: int) -> bool:
     return head_dim in (64, 128, 256)  # XQA headElems (mha.h static_assert)
 
 
+def is_supported_page_size(page_size: int) -> bool:
+    # XQA tokensPerPage template instantiations. Mamba-aligned hybrids (GDN) use
+    # ~800-token attention pages -> the leg is structurally unsupported there.
+    return page_size in (16, 32, 64, 128, 256)
+
+
+_DECLINED_CAPTURE_WARNED = False
+_DECLINED_PAGE_LOGGED = False
+
+
+def _log_unsupported_page(page_size: int) -> None:
+    global _DECLINED_PAGE_LOGGED
+    if not _DECLINED_PAGE_LOGGED:
+        _DECLINED_PAGE_LOGGED = True
+        logger.info(
+            "FLASHAMPERE xqa_verify disabled: page_size=%d unsupported by XQA "
+            "(needs one of 16/32/64/128/256; mamba-aligned hybrid geometry) -> "
+            "spec-verify runs on base FA", page_size,
+        )
+
+
+def _decline_page(page_size: int) -> None:
+    _log_unsupported_page(page_size)
+    raise KernelDecline
+
+
+def prewarm(
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    page_size: int,
+    head_dim: int,
+    grp: int,
+    q_seq_len: int,
+    num_reqs_list: list[int],
+    Hkv: int,
+    device: torch.device,
+) -> None:
+    """Build the XQA module + per-batch buffers eagerly, BEFORE cudagraph capture.
+
+    0.25.1 warmup dummy runs build non-spec metadata (draft=0 -> Phase.DECODE), so no
+    VERIFY-shaped eager call ever reaches xqa_verify before FULL-graph capture; the
+    first call per shape then lands inside capture and the :126 guard declines ->
+    base-FA is baked into every captured graph and the leg silently never fires.
+    Called from FlashAmpereMetadataBuilder.__init__ (pre-capture, eager, has config)."""
+    if not is_supported_page_size(page_size):
+        _log_unsupported_page(page_size)  # expected on mamba-aligned hybrids
+        return
+    _module(q_dtype, kv_dtype, page_size, head_dim, grp, q_seq_len)
+    for n in num_reqs_list:
+        _buffers(n, q_seq_len, Hkv, device)
+    logger.info(
+        "FLASHAMPERE xqa_verify prewarmed (q_seq_len=%d head_dim=%d grp=%d page=%d "
+        "num_reqs=%s)", q_seq_len, head_dim, grp, page_size, num_reqs_list,
+    )
+
+
 def xqa_verify(impl, layer, query, key, value, kv_cache, m, output):
     """MTP verify (uniform q=1+K) through famp's vendored XQA. CUDAGRAPH-SAFE."""
     num_reqs = m.seq_lens.shape[0]
@@ -111,6 +167,8 @@ def xqa_verify(impl, layer, query, key, value, kv_cache, m, output):
         raise KernelDecline
 
     key_cache, value_cache = kv_cache.unbind(1)  # [num_blocks, page_size, Hkv, D] (NHD == XQA NHD)
+    if not is_supported_page_size(key_cache.shape[1]):
+        _decline_page(key_cache.shape[1])  # before the KV write; base FA does its own
     _fa.reshape_and_cache_flash(
         key, value, key_cache, value_cache,
         m.slot_mapping, impl.kv_cache_dtype, layer._k_scale, layer._v_scale,
@@ -124,6 +182,15 @@ def xqa_verify(impl, layer, query, key, value, kv_cache, m, output):
     mod_key = (query.dtype, key_cache.dtype, page_size, D, H // Hkv, q_seq_len)
     buf_key = (num_reqs, q_seq_len, Hkv, dev)
     if (mod_key not in _MODULES or buf_key not in _BUFS) and torch.cuda.is_current_stream_capturing():
+        global _DECLINED_CAPTURE_WARNED
+        if not _DECLINED_CAPTURE_WARNED:
+            _DECLINED_CAPTURE_WARNED = True
+            logger.warning(
+                "FLASHAMPERE xqa_verify declined during capture (mod=%s bufs=%s not "
+                "prewarmed) -> base-FA baked into this graph; prewarm missed this "
+                "shape (mod_key=%s buf_key=%s)",
+                mod_key in _MODULES, buf_key in _BUFS, mod_key, buf_key,
+            )
         raise KernelDecline
 
     try:
@@ -132,8 +199,12 @@ def xqa_verify(impl, layer, query, key, value, kv_cache, m, output):
         raise KernelDecline from e
     sem, seq_u32, mask = _buffers(num_reqs, q_seq_len, Hkv, dev)
 
-    q5 = query.view(num_reqs, 1, q_seq_len, H, D)       # view of the (persistent) query buffer
-    out5 = output.view(num_reqs, 1, q_seq_len, H, D)
+    # The query/output buffers can be cudagraph-padded past the batch's actual tokens
+    # (metadata says nt, the tensor holds the padded graph size) -> slice before the
+    # view; a full-size slice is a no-op view, so this is capture-safe.
+    nt = num_reqs * q_seq_len
+    q5 = query[:nt].view(num_reqs, 1, q_seq_len, H, D)
+    out5 = output[:nt].view(num_reqs, 1, q_seq_len, H, D)
     # Fixed grid for cudagraph: max_seq_len = block_table capacity (constant per captured shape);
     # the kernel handles actual per-request seq_lens (GPU) <= this.
     max_seq_len = int(m.block_table.shape[1]) * page_size

--- a/vllm/tests/v1/attention/test_flashampere_dispatch.py
+++ b/vllm/tests/v1/attention/test_flashampere_dispatch.py
@@ -81,8 +81,13 @@ def test_fp16pv_legs_are_dtype_exclusive():
 
 
 def test_sage_owns_small_head_dims():
-    for hd in (64, 96, 128):
+    # hd64/96: sage only. hd128 joined the fp16-PV head sets for the BATCH prefill path
+    # (the legacy per-request leg declines hd<256 at runtime) -> fp16-PV row precedes sage.
+    for hd in (64, 96):
         assert _names(_key(Phase.PREFILL, hd)) == ("sage",), hd
+    assert _names(_key(Phase.PREFILL, 128, q_src=QSrc.HALF)) == ("fp16pv", "sage")
+    assert _names(_key(Phase.PREFILL, 128, q_src=QSrc.BF16)) == ("bf16cvt", "sage")
+    assert _names(_key(Phase.PREFILL, 128, q_src=QSrc.OTHER)) == ("sage",)
 
 
 def test_unsupported_head_dims_sink():

--- a/vllm/vllm/config/speculative.py
+++ b/vllm/vllm/config/speculative.py
@@ -884,14 +884,46 @@ class SpeculativeConfig:
                     )
 
                 # DSpark heads served on the V1 DFlash-family path declare a
-                # registered draft arch (DFlashDraftModel / Gemma4DSparkModel)
-                # and are wrapped in EAGLEConfig like dflash; upstream's
-                # Qwen3DSparkModel and in-target DeepSeek-V4 dspark surfaces
-                # are left untouched for the V2 model runner.
+                # registered draft arch and are wrapped in EAGLEConfig like
+                # dflash. Upstream/DeepSeek-official exports declare
+                # Qwen3DSparkModel; V1 serves them via the same DFlash-family
+                # class (normalized below), so one checkpoint format works on
+                # both this fork and upstream vLLM. In-target DeepSeek-V4
+                # dspark surfaces are left untouched for the V2 model runner.
                 dspark_v1_head = self.method == "dspark" and any(
-                    arch in ("DFlashDraftModel", "Gemma4DSparkModel")
+                    arch
+                    in ("DFlashDraftModel", "Gemma4DSparkModel", "Qwen3DSparkModel")
                     for arch in self.draft_model_config.architectures
                 )
+                if (
+                    dspark_v1_head
+                    and "Qwen3DSparkModel" in self.draft_model_config.architectures
+                ):
+                    # Normalize the upstream arch to the V1 DFlash-family class
+                    # (registry maps Qwen3DSparkModel to the V2-only class).
+                    self.draft_model_config.hf_config.architectures = [
+                        "DFlashDraftModel"
+                    ]
+                    # Some upstream exports carry the dflash keys at the top
+                    # level only; synthesize dflash_config so every downstream
+                    # reader sees the canonical layout.
+                    if not getattr(
+                        self.draft_model_config.hf_config, "dflash_config", None
+                    ):
+                        self.draft_model_config.hf_config.dflash_config = {
+                            k: v
+                            for k in (
+                                "markov_rank",
+                                "mask_token_id",
+                                "target_layer_ids",
+                            )
+                            if (
+                                v := getattr(
+                                    self.draft_model_config.hf_config, k, None
+                                )
+                            )
+                            is not None
+                        }
 
                 # Replace hf_config for EAGLE draft_model
                 if self.method in ("eagle", "eagle3", "dflash") or dspark_v1_head:

--- a/vllm/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/vllm/model_executor/models/qwen3_dflash.py
@@ -354,7 +354,9 @@ class DFlashQwen3Model(nn.Module):
         # embedding table at that slot id. Some (e.g. MiMo DFlash) ship a
         # separate mask embedding tensor; when present it is loaded and
         # substituted for embed_tokens[mask_token_id] at embedding time.
-        self.mask_token_id = drafter_config.get("mask_token_id")
+        self.mask_token_id = drafter_config.get(
+            "mask_token_id", getattr(self.config, "mask_token_id", None)
+        )
         self.mask_embedding = nn.Parameter(
             torch.zeros(self.config.hidden_size, dtype=vllm_config.model_config.dtype),
             requires_grad=False,
@@ -687,7 +689,13 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         # re-coupling adjacent draft-block positions (fixes parallel-draft accept decay).
         # markov_rank=0 => plain DFlash: head disabled, no params, no behavior change.
         dflash_cfg = getattr(self.config, "dflash_config", None) or {}
-        self.markov_rank = int(dflash_cfg.get("markov_rank", 0) or 0)
+        # Upstream/DeepSeek-official DSpark configs carry markov_rank at the
+        # top level; fork exports carry it in dflash_config. Accept both.
+        self.markov_rank = int(
+            dflash_cfg.get("markov_rank")
+            or getattr(self.config, "markov_rank", 0)
+            or 0
+        )
         if self.markov_rank > 0:
             self.markov_w1 = nn.Embedding(target_vocab_size, self.markov_rank)
             self.markov_w2 = nn.Linear(self.markov_rank, target_vocab_size, bias=False)

--- a/vllm/vllm/v1/attention/backends/flashampere/backend.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/backend.py
@@ -19,14 +19,37 @@ from __future__ import annotations
 
 from vllm.logger import init_logger
 from vllm.platforms.interface import DeviceCapability
-from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionBackend,
+    FlashAttentionMetadataBuilder,
+)
 
 from .impl import FlashAmpereImpl
 
 logger = init_logger(__name__)
 
 
+class FlashAmpereMetadataBuilder(FlashAttentionMetadataBuilder):
+    """FA builder + the CPU metadata twins the famp legs need for sync-free dispatch.
+
+    FlashAttentionMetadata carries only GPU query_start_loc/seq_lens; the legs used to
+    .tolist() them = 2 device syncs per LAYER per step (paid even when the mixed-batch
+    decline then sank the call to stock FA). CommonAttentionMetadata already holds the CPU
+    twins, but the impl never sees it — attach them here (once per STEP, no extra sync:
+    query_start_loc_cpu is a builder input; seq_lens_cpu a lazily-cached property)."""
+
+    def build(self, common_prefix_len, common_attn_metadata, fast_build: bool = False):
+        md = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        md.query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+        md.seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        return md
+
+
 class FlashAmpereBackend(FlashAttentionBackend):
+    @staticmethod
+    def get_builder_cls() -> type[FlashAmpereMetadataBuilder]:
+        return FlashAmpereMetadataBuilder
+
     @staticmethod
     def get_name() -> str:
         # Registered into the CUSTOM slot; AttentionBackendEnum["CUSTOM"] resolves cleanly.

--- a/vllm/vllm/v1/attention/backends/flashampere/backend.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/backend.py
@@ -17,6 +17,8 @@ change attention for every model.
 """
 from __future__ import annotations
 
+import torch
+
 from vllm.logger import init_logger
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends.flash_attn import (
@@ -43,6 +45,68 @@ class FlashAmpereMetadataBuilder(FlashAttentionMetadataBuilder):
         md.query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         md.seq_lens_cpu = common_attn_metadata.seq_lens_cpu
         return md
+
+    def __init__(self, kv_cache_spec, layer_names, vllm_config, device):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self._prewarm_xqa_verify(vllm_config, device)
+
+    def _prewarm_xqa_verify(self, vllm_config, device) -> None:
+        # 0.25.1 warmup dummy runs are non-spec (draft=0 -> Phase.DECODE), so the first
+        # VERIFY-shaped call per shape lands inside FULL-graph capture, where xqa_verify
+        # must decline (no JIT/alloc while capturing) -> base-FA gets baked into every
+        # captured graph and the leg never fires. Pre-build the module + per-batch
+        # buffers here: builder init runs eagerly in each worker before capture and has
+        # the full config. No-op unless the leg is enabled and spec-decode is on.
+        try:
+            from .impl import _caps
+            from . import xqa_verify as _xv
+
+            spec = vllm_config.speculative_config
+            if (
+                not _caps().enabled("xqa_verify")
+                or spec is None
+                or not spec.num_speculative_tokens
+                or not self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+            ):
+                return
+            q_seq_len = 1 + spec.num_speculative_tokens
+            head_dim = self.headdim
+            q_dtype = self.model_config.dtype
+            if not _xv.is_supported_head_dim(head_dim) or q_dtype not in (
+                torch.float16,
+                torch.bfloat16,
+            ):
+                return
+            # Mirror the dispatcher's uniform-decode req ladder:
+            # num_reqs = min(num_tokens_padded // q_seq_len, max_num_seqs).
+            max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+            sizes = self.compilation_config.cudagraph_capture_sizes or []
+            num_reqs_list = sorted(
+                {
+                    min(s // q_seq_len, max_num_seqs)
+                    for s in sizes
+                    if s >= q_seq_len and s % q_seq_len == 0
+                }
+            )
+            if not num_reqs_list:
+                return
+            _xv.prewarm(
+                q_dtype=q_dtype,
+                kv_dtype=self.kv_cache_dtype,
+                page_size=self.block_size,
+                head_dim=head_dim,
+                grp=self.num_heads_q // self.num_heads_kv,
+                q_seq_len=q_seq_len,
+                num_reqs_list=num_reqs_list,
+                Hkv=self.num_heads_kv,
+                device=device,
+            )
+        except Exception:
+            logger.warning(
+                "flashampere: xqa_verify prewarm failed; the VERIFY leg will decline "
+                "at capture and spec-verify will run on base FA",
+                exc_info=True,
+            )
 
 
 class FlashAmpereBackend(FlashAttentionBackend):

--- a/vllm/vllm/v1/attention/backends/flashampere/dispatch.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/dispatch.py
@@ -21,8 +21,8 @@ from typing import NamedTuple
 
 # Head dims each prefill leg accelerates. fp16-PV (fp16pv fp16-served / bf16cvt bf16-served) targets
 # the Qwen3.x hd256 full-attn layers; SageAttn targets the smaller dense hd's. Extend to widen.
-FP16PV_HEADS: tuple[int, ...] = (256, 512)  # fp16-served (q dtype == fp16); 512 = Gemma4 full-attn
-BF16CVT_HEADS: tuple[int, ...] = (256, 512)  # bf16-served (runtime upcast to fp16); 512 = Gemma4 full-attn
+FP16PV_HEADS: tuple[int, ...] = (128, 256, 512)  # fp16-served; 512=Gemma4; 128=BATCH path only
+BF16CVT_HEADS: tuple[int, ...] = (128, 256, 512)  # bf16-served (upcast); hd128 legacy leg declines
 XQA_VERIFY_HEADS: tuple[int, ...] = (64, 128, 256)  # MTP spec-verify (XQA headElems 64/128/256)
 SAGE_HEADS: tuple[int, ...] = (64, 96, 128)
 

--- a/vllm/vllm/v1/attention/backends/flashampere/impl.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/impl.py
@@ -68,9 +68,12 @@ class FlashAmpereImpl(FlashAttentionImpl):
         try:
             from vllm.config import get_current_vllm_config
 
-            self._fc_max_num_seqs = get_current_vllm_config().scheduler_config.max_num_seqs
+            _sc = get_current_vllm_config().scheduler_config
+            self._fc_max_num_seqs = _sc.max_num_seqs
+            self._fc_max_num_batched_tokens = _sc.max_num_batched_tokens
         except Exception:
             self._fc_max_num_seqs = None
+            self._fc_max_num_batched_tokens = None
 
     @staticmethod
     def _nonplain_metadata(m) -> bool:

--- a/vllm/vllm/v1/attention/backends/flashampere/impl.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/impl.py
@@ -7,6 +7,8 @@ capability.py. The base FA forward already carries the MTP-verify fwd_kvcache fi
 (VLLM_FA2_KVCACHE_VERIFY), so VERIFY and DECODE sink to it unchanged."""
 from __future__ import annotations
 
+import os
+
 import torch
 
 from vllm.logger import init_logger
@@ -191,6 +193,13 @@ class FlashAmpereImpl(FlashAttentionImpl):
         # ever fires defensively (incl. spec-decode capture, where verify already sank above).
         capturing = torch.cuda.is_current_stream_capturing()
 
+        if os.environ.get("FAMP_DEBUG_DISPATCH"):
+            _ent = [e.name for e in resolve(key_t)]
+            logger.info(
+                "famp-debug phase=%s hd=%s qdt=%s entries=%s enabled=%s",
+                phase, self.head_size, query.dtype, _ent,
+                [n for n in _ent if self._caps.enabled(n)],
+            )
         for entry in resolve(key_t):
             if capturing and not entry.capture_safe:
                 continue

--- a/vllm/vllm/v1/attention/backends/flashampere/impl.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/impl.py
@@ -82,11 +82,18 @@ class FlashAmpereImpl(FlashAttentionImpl):
           - sliding_window on the METADATA (batch-level override of the impl's static window),
           - rswa_prefix_lens / rswa_window / rswa_window_tensor (Reference-SWA masking).
         Any of these set/non-default -> sink to stock FA (bit-faithful; FA implements them).
-        getattr defaults keep this a no-op on 0.23-era metadata (fields absent)."""
+        getattr defaults keep this a no-op on 0.23-era metadata (fields absent).
+        NB: 0.25.1 populates sliding_window=(-1, -1) unconditionally as the no-window sentinel —
+        normalize it before the check, else every batch reads nonplain and the legs go dead."""
+        sw = getattr(m, "sliding_window", None)
+        if isinstance(sw, (tuple, list)):
+            sw = None if tuple(sw) == (-1, -1) else sw
+        elif sw == -1:
+            sw = None
         return (
             isinstance(getattr(m, "causal", True), torch.Tensor)
             or getattr(m, "mm_prefix_range_tensor", None) is not None
-            or getattr(m, "sliding_window", None) is not None
+            or sw is not None
             or getattr(m, "rswa_prefix_lens", None) is not None
             or getattr(m, "rswa_window", None) is not None
             or getattr(m, "rswa_window_tensor", None) is not None

--- a/vllm/vllm/v1/attention/backends/flashampere/kernels.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/kernels.py
@@ -49,6 +49,16 @@ _FP16_MAX = 65504.0
 # Per-PROCESS one-time "fired here" latch -> a per-rank log line under TP/PP (separate procs).
 _FIRED_LOGGED = False
 
+# Batch-prefill fast path: skip the defensive out.zero_() before paged_run (FI's run() inits out
+# with torch.zeros; the fa2 kernel/merge writes every row, so the zero is believed redundant —
+# A/B knob until validated, then default flips).
+_BP_ZERO = os.environ.get("FAMP_BP_NOZERO", "0") not in ("1", "true", "True")
+
+# Batch-prefill engagement floor: steps with fewer total query tokens than this (prefix-cache
+# hits, tiny tail chunks) stay on stock FA — the batch path's per-step plan() costs more than
+# its kernel win on few-ms ops. Measured crossover O(hundreds) of tokens on RTX 3090.
+_BP_MIN_TOKENS = int(os.environ.get("FAMP_BP_MIN_TOKENS", "512"))
+
 is_quantized_kv_cache = _fa.is_quantized_kv_cache
 
 
@@ -113,18 +123,19 @@ class _BatchPrefillState:
         self.kvdtype = kv_cache.dtype
         self.ws = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=dev)
         self.wrapper = None
-        self._planned_meta_id: int | None = None
-        # Scatter-compact constants for the sync-free indices flatten (same trick as
-        # _Hd512DecodeState._build_meta: fixed-size dest + trash slot, sliced by a CPU-known total).
-        self._col = None
-        self._buf = None
-        # paged_run fast-path template (recorded per step on the first layer): the FI wrapper's
-        # per-layer python (arg assembly + checks, ~200us/layer) does not hide under short kernels
-        # and was the residual e2e loss. Layers 2..N swap q/k/v/out into the recorded args by
-        # position and call module.paged_run directly (one ffi call).
+        # Scatter-compact machinery for the sync-free indices flatten (sized lazily; mb =
+        # block_table columns is unknown until the first step).
+        self._col = self._scatter = None
+        # paged_run template, recorded ONCE EVER: plan() hands the wrapper NEW plan-input tensors
+        # + plan_info each step -> plan_step refreshes those recorded slots; run_fast swaps only
+        # q/k/v/out per layer. NB non-graph wrapper on purpose: cuda-graph mode schedules every
+        # step at the locked worst-case row ceiling (args[6]=max_total_num_rows) -> padded grids,
+        # measured e2e loss; eager prefill wants exact per-step grids.
         self._tmpl: list | None = None
         self._kw: dict | None = None
-        self._pos: tuple[int, int, int, int] | None = None
+        self._pos: tuple[int, int, int, int] | None = None       # q, k, v, out arg slots
+        self._plan_slots: tuple[tuple[int, str], ...] | None = None  # (slot, wrapper attr)
+        self._planned: tuple | None = None
 
     def _get_wrapper(self):
         if self.wrapper is None:
@@ -137,62 +148,77 @@ class _BatchPrefillState:
         return self.wrapper
 
     def plan_step(self, m, qsl_cpu, sl_cpu):
-        """Plan once per step (id(m) = per-step metadata identity); later layers reuse."""
-        w = self._get_wrapper()
-        if self._planned_meta_id == id(m):
-            return w
-        self._tmpl = None  # new step -> re-record the paged_run arg template on the first layer
-        ps = self.ps
-        sl = sl_cpu.to(torch.int32)
-        npg_cpu = (sl + ps - 1) // ps
-        kv_indptr_cpu = torch.zeros(sl.numel() + 1, dtype=torch.int32)
-        kv_indptr_cpu[1:] = torch.cumsum(npg_cpu, 0).to(torch.int32)
-        klp_cpu = (sl - (npg_cpu - 1) * ps).to(torch.int32)
-        # Flatten the first npg[i] block ids of each block_table row WITHOUT a device sync:
-        # scatter valid entries to compacted positions in a fixed-size buffer (+1 trash slot),
-        # then slice by the CPU-known total page count.
-        bt = m.block_table
-        B, mb = bt.shape[0], bt.shape[1]
-        dev = bt.device
-        if self._col is None or self._col.numel() < B * mb:
-            self._col = torch.arange(mb, device=dev).unsqueeze(0).expand(B, -1).reshape(-1)
-            self._buf = torch.zeros(B * mb + 1, dtype=torch.int32, device=dev)
-        npg_dev = (m.seq_lens + ps - 1) // ps                                  # [B] GPU
-        col = self._col[: B * mb]
-        valid = col < npg_dev.unsqueeze(1).expand(-1, mb).reshape(-1)
-        out_pos = torch.cumsum(valid.to(torch.int64), 0) - 1
-        dest = torch.where(valid, out_pos, torch.full_like(out_pos, self._buf.numel() - 1))
-        self._buf.zero_()
-        self._buf.scatter_(0, dest, bt.reshape(-1).to(torch.int32))
-        total = int(kv_indptr_cpu[-1])
-        indices = self._buf[:total]
-        w.plan(
-            qsl_cpu.to(torch.int32), kv_indptr_cpu, indices, klp_cpu,
-            self.Hq, self.Hkv, self.D, ps, causal=True, sm_scale=self.sm,
-            window_left=-1, q_data_type=torch.float16, kv_data_type=self.kvdtype,
-        )
-        self._planned_meta_id = id(m)
+        """Plan once per step; refresh the template's plan-dependent slots. Any plan shortfall
+        declines the step to stock FA instead of raising."""
+        B = sl_cpu.numel()
+        # id(m) alone is unsafe (CPython reuses freed addresses across steps) -> add a cheap
+        # content fingerprint from the CPU twins (no device sync).
+        key = (id(m), B, int(qsl_cpu[-1]), int(sl_cpu.sum()))
+        if self._planned == key:
+            return self.wrapper
+        try:
+            w = self._get_wrapper()
+            ps = self.ps
+            sl = sl_cpu.to(torch.int32)
+            npg_cpu = (sl + ps - 1) // ps
+            kv_indptr_cpu = torch.zeros(B + 1, dtype=torch.int32)
+            kv_indptr_cpu[1:] = torch.cumsum(npg_cpu, 0).to(torch.int32)
+            klp_cpu = (sl - (npg_cpu - 1) * ps).to(torch.int32)
+            # Flatten the first npg[i] block ids of each block_table row WITHOUT a device sync:
+            # scatter valid entries to compacted positions (+1 trash slot), slice by the
+            # CPU-known total page count.
+            bt = m.block_table
+            mb = bt.shape[1]
+            dev = bt.device
+            if self._col is None or self._col.numel() < B * mb:
+                n = max(B, 8)
+                self._col = torch.arange(mb, device=dev).repeat(n)
+                self._scatter = torch.zeros(n * mb + 1, dtype=torch.int32, device=dev)
+            npg_dev = (m.seq_lens + ps - 1) // ps                              # [B] GPU
+            col = self._col[: B * mb]
+            valid = col < npg_dev.unsqueeze(1).expand(-1, mb).reshape(-1)
+            out_pos = torch.cumsum(valid.to(torch.int64), 0) - 1
+            dest = torch.where(valid, out_pos, torch.full_like(out_pos, self._scatter.numel() - 1))
+            self._scatter.zero_()
+            self._scatter.scatter_(0, dest, bt.reshape(-1).to(torch.int32))
+            total = int(kv_indptr_cpu[-1])
+            w.plan(
+                qsl_cpu.to(torch.int32), kv_indptr_cpu, self._scatter[:total], klp_cpu,
+                self.Hq, self.Hkv, self.D, ps, causal=True, sm_scale=self.sm,
+                window_left=-1, q_data_type=torch.float16, kv_data_type=self.kvdtype,
+            )
+        except KernelDecline:
+            raise
+        except Exception as e:
+            logger.warning_once("famp batch_prefill plan declined: %s", e)
+            raise KernelDecline from e
+        if self._tmpl is not None and self._plan_slots is not None:
+            t = self._tmpl
+            for i, attr in self._plan_slots:
+                t[i] = getattr(w, attr)
+        self._planned = key
         return w
 
     def run_fast(self, w, q, kv_cache, out):
-        """First layer of a step: full wrapper.run with a paged_run recorder (correct-by-
-        construction args, whatever the FI patch level passes). Later layers: swap the four
-        per-layer tensors into the recorded template by identity/data_ptr and call the module's
-        paged_run directly. Falls back to wrapper.run whenever positions can't be located."""
+        """Record ONCE EVER: the first call goes through the full wrapper.run under a paged_run
+        recorder (args correct-by-construction for whatever the FI patch level passes). Every
+        subsequent layer of every step is one direct module.paged_run ffi call: plan-dependent
+        slots are refreshed in plan_step, q/k/v/out swapped here by recorded position."""
         mod = w._cached_module
         kc, vc = kv_cache.unbind(1)
         if self._tmpl is not None and self._pos is not None:
             iq, ik, iv, io = self._pos
             t = self._tmpl
             t[iq], t[ik], t[iv], t[io] = q, kc, vc, out
-            out.zero_()  # match FI's torch.zeros out-init (split-KV merge contract)
+            if _BP_ZERO:
+                out.zero_()  # FI's torch.zeros out-init; FAMP_BP_NOZERO=1 skips it (A/B knob)
             mod.paged_run(*t, **self._kw)
             return out
         rec: dict = {}
         orig = mod.paged_run
-        def _recorder(*a, **kw):
-            rec["a"], rec["kw"] = list(a), dict(kw)
-            return orig(*a, **kw)
+        def _recorder(*args_, **kw_):
+            rec["a"], rec["kw"] = list(args_), dict(kw_)
+            return orig(*args_, **kw_)
         mod.paged_run = _recorder
         try:
             out.zero_()
@@ -210,8 +236,22 @@ class _BatchPrefillState:
                         return i
                 return -1
             iq, ik, iv, io = _find(q), _find(kc), _find(vc), _find(out)
-            if -1 not in (iq, ik, iv, io):
-                self._tmpl, self._kw, self._pos = a, rec.get("kw") or {}, (iq, ik, iv, io)
+            # Slots the wrapper REPLACES on every plan(): collect ALL occurrences per attr (the
+            # extended fa2 tail repeats qo/kv indptr) so each step's refresh covers every copy.
+            slots: list[tuple[int, str]] = []
+            ok = True
+            for attr in ("_plan_info", "_qo_indptr_buf", "_paged_kv_indptr_buf",
+                         "_paged_kv_indices_buf", "_paged_kv_last_page_len_buf"):
+                obj = getattr(w, attr, None)
+                found = [j for j, v in enumerate(a) if v is obj] if obj is not None else []
+                if not found:
+                    ok = False
+                    break
+                slots.extend((j, attr) for j in found)
+            if ok and -1 not in (iq, ik, iv, io):
+                self._tmpl, self._kw = a, rec.get("kw") or {}
+                self._pos = (iq, ik, iv, io)
+                self._plan_slots = tuple(slots)
         return o
 
 
@@ -287,6 +327,9 @@ def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: 
         and _sl_cpu is not None
         and qlens
         and min(qlens) > 1
+        # Small-q steps (prefix-cache hits, tail chunks) are a few-ms op where the per-step
+        # plan() tax exceeds the kernel win — leave those to stock FA. Full chunks engage.
+        and int(_qsl_cpu[-1]) >= _BP_MIN_TOKENS
     ):
         return _batch_prefill_run(
             impl, layer, query, key, value, kv_cache, m, output, _qsl_cpu, _sl_cpu, leg

--- a/vllm/vllm/v1/attention/backends/flashampere/kernels.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/kernels.py
@@ -118,6 +118,13 @@ class _BatchPrefillState:
         # _Hd512DecodeState._build_meta: fixed-size dest + trash slot, sliced by a CPU-known total).
         self._col = None
         self._buf = None
+        # paged_run fast-path template (recorded per step on the first layer): the FI wrapper's
+        # per-layer python (arg assembly + checks, ~200us/layer) does not hide under short kernels
+        # and was the residual e2e loss. Layers 2..N swap q/k/v/out into the recorded args by
+        # position and call module.paged_run directly (one ffi call).
+        self._tmpl: list | None = None
+        self._kw: dict | None = None
+        self._pos: tuple[int, int, int, int] | None = None
 
     def _get_wrapper(self):
         if self.wrapper is None:
@@ -134,6 +141,7 @@ class _BatchPrefillState:
         w = self._get_wrapper()
         if self._planned_meta_id == id(m):
             return w
+        self._tmpl = None  # new step -> re-record the paged_run arg template on the first layer
         ps = self.ps
         sl = sl_cpu.to(torch.int32)
         npg_cpu = (sl + ps - 1) // ps
@@ -166,6 +174,46 @@ class _BatchPrefillState:
         self._planned_meta_id = id(m)
         return w
 
+    def run_fast(self, w, q, kv_cache, out):
+        """First layer of a step: full wrapper.run with a paged_run recorder (correct-by-
+        construction args, whatever the FI patch level passes). Later layers: swap the four
+        per-layer tensors into the recorded template by identity/data_ptr and call the module's
+        paged_run directly. Falls back to wrapper.run whenever positions can't be located."""
+        mod = w._cached_module
+        kc, vc = kv_cache.unbind(1)
+        if self._tmpl is not None and self._pos is not None:
+            iq, ik, iv, io = self._pos
+            t = self._tmpl
+            t[iq], t[ik], t[iv], t[io] = q, kc, vc, out
+            out.zero_()  # match FI's torch.zeros out-init (split-KV merge contract)
+            mod.paged_run(*t, **self._kw)
+            return out
+        rec: dict = {}
+        orig = mod.paged_run
+        def _recorder(*a, **kw):
+            rec["a"], rec["kw"] = list(a), dict(kw)
+            return orig(*a, **kw)
+        mod.paged_run = _recorder
+        try:
+            out.zero_()
+            o = w.run(q, kv_cache, out=out)
+        finally:
+            mod.paged_run = orig
+        a = rec.get("a")
+        if a is not None:
+            def _find(x):
+                for i, v in enumerate(a):
+                    if v is x or (
+                        isinstance(v, torch.Tensor) and isinstance(x, torch.Tensor)
+                        and v.data_ptr() == x.data_ptr() and v.shape == x.shape
+                    ):
+                        return i
+                return -1
+            iq, ik, iv, io = _find(q), _find(kc), _find(vc), _find(out)
+            if -1 not in (iq, ik, iv, io):
+                self._tmpl, self._kw, self._pos = a, rec.get("kw") or {}, (iq, ik, iv, io)
+        return o
+
 
 _BP_STATES: dict[tuple, _BatchPrefillState] = {}
 
@@ -182,8 +230,7 @@ def _batch_prefill_run(impl, layer, query, key, value, kv_cache, m, output, qsl_
         st = _BP_STATES[skey] = _BatchPrefillState(impl, kv_cache, query.device)
     w = st.plan_step(m, qsl_cpu, sl_cpu)
     q = query.reshape(-1, impl.num_heads, impl.head_size)
-    o = w.run(q, kv_cache)
-    output.copy_(o.reshape(output.shape))
+    st.run_fast(w, q, kv_cache, output.reshape(q.shape))
     FIRE["calls"] += 1
     FIRE["batch"] += 1
     _log_fired_once("batch_prefill", int(q.shape[0]), -1, impl.head_size)

--- a/vllm/vllm/v1/attention/backends/flashampere/kernels.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/kernels.py
@@ -37,7 +37,7 @@ except Exception as e:  # pragma: no cover - import guard
     logger.warning("flashinfer not importable (%s); flashampere prefill legs delegate to FA.", e)
 
 # Fire counter (read by the validation harness): totals + per-leg breakdown.
-FIRE = {"calls": 0, "seqs": 0, "fresh": 0, "cached": 0, "fp16pv": 0, "bf16cvt": 0}
+FIRE = {"calls": 0, "seqs": 0, "fresh": 0, "cached": 0, "fp16pv": 0, "bf16cvt": 0, "batch": 0}
 
 # bf16->fp16 upcast is lossless for attention inputs in the fp16 NORMAL range (fp16 carries 10
 # mantissa bits vs bf16's 7), but bf16's wider exponent can hold values above fp16 max (65504).
@@ -99,6 +99,97 @@ def _log_fired_once(leg: str, Lq: int, ctx: int, D: int) -> None:
     )
 
 
+class _BatchPrefillState:
+    """De-taxed PREFILL: ONE batched paged-KV BatchPrefill run per layer on famp's vendored
+    fp16-PV kernel (wrapper._jit_module injection), planned ONCE per step from the CPU metadata
+    twins — no per-request loop, no paged->contiguous gather, no KV cast, zero device syncs.
+    Phase-1 scope: fp16-served only (FA_PV16 needs DTypeQ==half and an fp16 KV cache); eager
+    (prefill is not captured). One state per (layer head-config, page size)."""
+
+    def __init__(self, impl, kv_cache, dev):
+        self.Hq, self.Hkv, self.D = impl.num_heads, impl.num_kv_heads, impl.head_size
+        self.sm = impl.scale
+        self.ps = kv_cache.shape[2]
+        self.kvdtype = kv_cache.dtype
+        self.ws = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=dev)
+        self.wrapper = None
+        self._planned_meta_id: int | None = None
+        # Scatter-compact constants for the sync-free indices flatten (same trick as
+        # _Hd512DecodeState._build_meta: fixed-size dest + trash slot, sliced by a CPU-known total).
+        self._col = None
+        self._buf = None
+
+    def _get_wrapper(self):
+        if self.wrapper is None:
+            from .prefill._jit_batch_prefill import install_famp_batch_prefill
+
+            # By-key spec shim: plan() resolves the standard module path to famp's vendored
+            # fp16-PV kernel for exactly this config; other keys stay stock.
+            install_famp_batch_prefill(torch.float16, self.kvdtype, torch.float16, self.D)
+            self.wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(self.ws, "NHD")
+        return self.wrapper
+
+    def plan_step(self, m, qsl_cpu, sl_cpu):
+        """Plan once per step (id(m) = per-step metadata identity); later layers reuse."""
+        w = self._get_wrapper()
+        if self._planned_meta_id == id(m):
+            return w
+        ps = self.ps
+        sl = sl_cpu.to(torch.int32)
+        npg_cpu = (sl + ps - 1) // ps
+        kv_indptr_cpu = torch.zeros(sl.numel() + 1, dtype=torch.int32)
+        kv_indptr_cpu[1:] = torch.cumsum(npg_cpu, 0).to(torch.int32)
+        klp_cpu = (sl - (npg_cpu - 1) * ps).to(torch.int32)
+        # Flatten the first npg[i] block ids of each block_table row WITHOUT a device sync:
+        # scatter valid entries to compacted positions in a fixed-size buffer (+1 trash slot),
+        # then slice by the CPU-known total page count.
+        bt = m.block_table
+        B, mb = bt.shape[0], bt.shape[1]
+        dev = bt.device
+        if self._col is None or self._col.numel() < B * mb:
+            self._col = torch.arange(mb, device=dev).unsqueeze(0).expand(B, -1).reshape(-1)
+            self._buf = torch.zeros(B * mb + 1, dtype=torch.int32, device=dev)
+        npg_dev = (m.seq_lens + ps - 1) // ps                                  # [B] GPU
+        col = self._col[: B * mb]
+        valid = col < npg_dev.unsqueeze(1).expand(-1, mb).reshape(-1)
+        out_pos = torch.cumsum(valid.to(torch.int64), 0) - 1
+        dest = torch.where(valid, out_pos, torch.full_like(out_pos, self._buf.numel() - 1))
+        self._buf.zero_()
+        self._buf.scatter_(0, dest, bt.reshape(-1).to(torch.int32))
+        total = int(kv_indptr_cpu[-1])
+        indices = self._buf[:total]
+        w.plan(
+            qsl_cpu.to(torch.int32), kv_indptr_cpu, indices, klp_cpu,
+            self.Hq, self.Hkv, self.D, ps, causal=True, sm_scale=self.sm,
+            window_left=-1, q_data_type=torch.float16, kv_data_type=self.kvdtype,
+        )
+        self._planned_meta_id = id(m)
+        return w
+
+
+_BP_STATES: dict[tuple, _BatchPrefillState] = {}
+
+
+def _batch_prefill_run(impl, layer, query, key, value, kv_cache, m, output, qsl_cpu, sl_cpu, leg):
+    key_cache, value_cache = kv_cache.unbind(1)
+    _reshape_and_cache_flash(
+        key, value, key_cache, value_cache,
+        m.slot_mapping, impl.kv_cache_dtype, layer._k_scale, layer._v_scale,
+    )
+    skey = (impl.num_heads, impl.num_kv_heads, impl.head_size, kv_cache.dtype, kv_cache.shape[2])
+    st = _BP_STATES.get(skey)
+    if st is None:
+        st = _BP_STATES[skey] = _BatchPrefillState(impl, kv_cache, query.device)
+    w = st.plan_step(m, qsl_cpu, sl_cpu)
+    q = query.reshape(-1, impl.num_heads, impl.head_size)
+    o = w.run(q, kv_cache)
+    output.copy_(o.reshape(output.shape))
+    FIRE["calls"] += 1
+    FIRE["batch"] += 1
+    _log_fired_once("batch_prefill", int(q.shape[0]), -1, impl.head_size)
+    return output
+
+
 def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: str = "fp16pv"):
     """fp16-PV prefill — gather/loop + fp16 FlashInfer with use_fp16_pv_reduction. Casts Q/K/V to fp16
     and runs FlashInfer with use_fp16_pv_reduction (DTypeProb=half). Serves BOTH:
@@ -114,10 +205,18 @@ def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: 
     if not _HAS_FI:
         raise KernelDecline
     guard_fp16 = leg == "bf16cvt"  # bf16 source: range-check Q/K/V before upcast (else inf on cast)
-    cu_list = m.query_start_loc.tolist()
+    # CPU twins attached by FlashAmpereMetadataBuilder -> zero device syncs here (and none paid
+    # when the mixed-batch check below declines). Device-tensor .tolist() is the legacy fallback.
+    _qsl_cpu = getattr(m, "query_start_loc_cpu", None)
+    _sl_cpu = getattr(m, "seq_lens_cpu", None)
+    if _qsl_cpu is not None and _sl_cpu is not None:
+        cu_list = _qsl_cpu.tolist()
+        seq_lens_cpu = _sl_cpu.tolist()
+    else:
+        cu_list = m.query_start_loc.tolist()
+        seq_lens_cpu = m.seq_lens.tolist()
     n_req = len(cu_list) - 1
     qlens = [int(cu_list[i + 1] - cu_list[i]) for i in range(n_req)]
-    seq_lens_cpu = m.seq_lens.tolist()
     # A decode row (q=1, ctx>0) mixed into a prefill batch (continuous batching) is the one shape FI
     # single_prefill can't do (q_len=1 -> max_mma_kv=0). For hd<=256 we DECLINE so stock FA handles
     # the whole mixed batch optimally. For hd>256 (Gemma4 512) FA has NO path (head_size>256 reject),
@@ -126,6 +225,29 @@ def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: 
         for i in range(n_req):
             if qlens[i] == 1 and seq_lens_cpu[i] > 1:
                 raise KernelDecline
+
+    # De-taxed batched path (opt-in VLLM_FAMP_BATCH_PREFILL=1): one paged BatchPrefill run on the
+    # vendored fp16-PV kernel — no gather/loop/casts. Phase-1 scope: fp16-served (FA_PV16 needs
+    # half Q AND half KV cache), hd<=256, CPU metadata present, no q_len=1 rows (paged q-tile floor).
+    batch_on = os.environ.get("VLLM_FAMP_BATCH_PREFILL", "0") in ("1", "true", "True")
+    if (
+        batch_on
+        and leg == "fp16pv"
+        and impl.head_size <= 256
+        and query.dtype == torch.float16
+        and kv_cache.dtype == torch.float16
+        and _qsl_cpu is not None
+        and _sl_cpu is not None
+        and qlens
+        and min(qlens) > 1
+    ):
+        return _batch_prefill_run(
+            impl, layer, query, key, value, kv_cache, m, output, _qsl_cpu, _sl_cpu, leg
+        )
+    # hd<256 through the LEGACY per-request leg measured e2e-NEGATIVE (leg tax > kernel win,
+    # −14..−48% TTFT on Qwen3-8B) — only the de-taxed batch path above may take those heads.
+    if impl.head_size < 256:
+        raise KernelDecline
 
     key_cache, value_cache = kv_cache.unbind(1)
     _reshape_and_cache_flash(
@@ -162,8 +284,17 @@ def fp16pv_prefill(impl, layer, query, key, value, kv_cache, m, output, *, leg: 
         # (NaN fails the <=), so the leg never forwards a non-finite tensor into the cubin. Never
         # fires for real O(1-50) post-norm activations; pure insurance.
         if guard_fp16:
-            mx = max(float(q_src.abs().amax()), float(k_src.abs().amax()), float(v_src.abs().amax()))
-            if not (mx <= _FP16_MAX):
+            # One fused inf-norm per operand (no materialized .abs()) + a SINGLE device sync for
+            # all three (was 3 abs+amax kernels + 3 .item() syncs = the largest leg overhead,
+            # 41-46% measured). NaN still fails the <= (vector_norm propagates it).
+            mx = torch.maximum(
+                torch.maximum(
+                    torch.linalg.vector_norm(q_src, ord=float("inf")),
+                    torch.linalg.vector_norm(k_src, ord=float("inf")),
+                ),
+                torch.linalg.vector_norm(v_src, ord=float("inf")),
+            )
+            if not (float(mx) <= _FP16_MAX):
                 raise KernelDecline
         q = q_src.to(torch.float16)
         k = k_src.to(torch.float16)

--- a/vllm/vllm/v1/attention/backends/flashampere/prefill/_jit_batch_prefill.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/prefill/_jit_batch_prefill.py
@@ -1,0 +1,67 @@
+"""famp owned FA2 BATCH paged prefill (fp16-PV) — the de-taxed prefill path.
+
+Injection point: flashinfer's standard batch-prefill flow is
+    wrapper.plan() -> get_batch_prefill_module(backend, *args)   [functools.cache]
+                   -> gen_batch_prefill_module(backend, *args).build_and_load()
+We shim `gen_batch_prefill_module` in flashinfer.prefill's namespace with a BY-EXACT-KEY
+override: famp's config keys resolve to a JitSpec rebuilt under famp's name with the VENDORED
+prefill.cuh first on the include path (FA_PV16 fp16-PV epilogue + the sm86 tile heuristic);
+every other key defers to stock flashinfer (e.g. the hd512 bf16 decode wrapper). This keeps the
+wrapper's standard plan/run ABI (the `_jit_module` ctor path expects the CUSTOMIZE codegen ABI —
+16-arg plan — and is NOT usable for a standard-ABI kernel; measured mismatch 19-vs-16).
+Install BEFORE the first plan() for the key (get_batch_prefill_module caches per key)."""
+import pathlib
+
+import torch
+from flashinfer.jit.attention.modules import gen_batch_prefill_module as _stock_gen
+from flashinfer.jit.core import JitSpec, gen_jit_spec
+
+_INC = pathlib.Path(__file__).parent / "include"  # vendored flashinfer/attention/prefill.cuh
+
+
+def _famp_spec(backend, *args, use_fp16_pv: bool = True) -> JitSpec:
+    base = _stock_gen(backend, *args)
+    extra_cflags = ["-DFA_USE_FP16_PV=1"] if use_fp16_pv else []
+    inc = [str(_INC)] + [str(p) for p in (base.extra_include_dirs or [])]
+    return gen_jit_spec(
+        "famp_" + base.name,                       # unique name -> fresh build dir, our settings
+        base.sources,                              # flashinfer's generated binding (ABI match)
+        extra_cflags=base.extra_cflags,
+        extra_cuda_cflags=list(base.extra_cuda_cflags) + extra_cflags,
+        extra_ldflags=base.extra_ldflags,
+        extra_include_paths=inc,                   # OUR prefill.cuh first
+        needs_device_linking=base.needs_device_linking,
+    )
+
+
+def install_famp_batch_prefill(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    head_dim: int,
+    use_fp16_pv: bool = True,
+) -> None:
+    """Idempotently route this exact batch-prefill config to the famp spec (in-process only)."""
+    import flashinfer.prefill as fip
+
+    key = (
+        "fa2", dtype_q, dtype_kv, dtype_o, torch.int32, head_dim, head_dim,
+        0,      # PosEncodingMode NONE
+        False,  # use_sliding_window
+        False,  # use_logits_soft_cap
+        False,  # use_fp16_qk_reduction
+    )
+    cur = fip.gen_batch_prefill_module
+    if not getattr(cur, "_famp_shim", False):
+        overrides: dict[tuple, JitSpec] = {}
+
+        def _shim(backend, *args):
+            spec = overrides.get((backend, *args))
+            return spec if spec is not None else _stock_gen(backend, *args)
+
+        _shim._famp_shim = True
+        _shim._famp_overrides = overrides
+        fip.gen_batch_prefill_module = _shim
+        cur = _shim
+    if key not in cur._famp_overrides:
+        cur._famp_overrides[key] = _famp_spec(*key, use_fp16_pv=use_fp16_pv)

--- a/vllm/vllm/v1/attention/backends/flashampere/prefill/include/flashinfer/attention/prefill.cuh
+++ b/vllm/vllm/v1/attention/backends/flashampere/prefill/include/flashinfer/attention/prefill.cuh
@@ -25,6 +25,8 @@
 #endif
 #include <cuda_runtime.h>
 
+#include <cstdlib>
+
 #include <flashinfer/cp_async.cuh>
 #include <flashinfer/fastdiv.cuh>
 #ifdef FP16_QK_REDUCTION_SUPPORTED
@@ -2162,6 +2164,21 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
   constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
   int64_t packed_qo_len = qo_len * group_size;
   uint32_t cta_tile_q = FA2DetermineCtaTileQ(packed_qo_len, HEAD_DIM_VO);
+  // famp: on GA10x (sm86, 99KB smem/CTA cap) the 64-row Q tile beats 128 for short/mid prefill —
+  // NUM_MMA_Q=1 shortens the per-fragment MMA dependency chain and doubles CTA-level parallelism.
+  // Measured on RTX 3090 hd128: +6..23% for packed_qo_len<=16k, ~0..-2% above (crossover 16k-32k),
+  // so switch below the guaranteed-win zone only. hd256 unmeasured -> untouched.
+  // FAMP_CTA_TILE_Q overrides for experiments.
+  if (cta_tile_q > 64 && HEAD_DIM_VO == 128 && packed_qo_len <= 16384) {
+    int _dev = 0, _major = 0, _minor = 0;
+    FLASHINFER_CUDA_CALL(cudaGetDevice(&_dev));
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&_major, cudaDevAttrComputeCapabilityMajor, _dev));
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&_minor, cudaDevAttrComputeCapabilityMinor, _dev));
+    if (_major == 8 && _minor >= 6) cta_tile_q = 64;
+  }
+  if (const char* _ftq = std::getenv("FAMP_CTA_TILE_Q")) {
+    cta_tile_q = static_cast<uint32_t>(std::atoi(_ftq));
+  }
 
   DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
     constexpr uint32_t NUM_WARPS_Q = get_num_warps_q(CTA_TILE_Q);

--- a/vllm/vllm/v1/attention/backends/flashampere/xqa_verify.py
+++ b/vllm/vllm/v1/attention/backends/flashampere/xqa_verify.py
@@ -99,6 +99,62 @@ def is_supported_head_dim(head_dim: int) -> bool:
     return head_dim in (64, 128, 256)  # XQA headElems (mha.h static_assert)
 
 
+def is_supported_page_size(page_size: int) -> bool:
+    # XQA tokensPerPage template instantiations. Mamba-aligned hybrids (GDN) use
+    # ~800-token attention pages -> the leg is structurally unsupported there.
+    return page_size in (16, 32, 64, 128, 256)
+
+
+_DECLINED_CAPTURE_WARNED = False
+_DECLINED_PAGE_LOGGED = False
+
+
+def _log_unsupported_page(page_size: int) -> None:
+    global _DECLINED_PAGE_LOGGED
+    if not _DECLINED_PAGE_LOGGED:
+        _DECLINED_PAGE_LOGGED = True
+        logger.info(
+            "FLASHAMPERE xqa_verify disabled: page_size=%d unsupported by XQA "
+            "(needs one of 16/32/64/128/256; mamba-aligned hybrid geometry) -> "
+            "spec-verify runs on base FA", page_size,
+        )
+
+
+def _decline_page(page_size: int) -> None:
+    _log_unsupported_page(page_size)
+    raise KernelDecline
+
+
+def prewarm(
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    page_size: int,
+    head_dim: int,
+    grp: int,
+    q_seq_len: int,
+    num_reqs_list: list[int],
+    Hkv: int,
+    device: torch.device,
+) -> None:
+    """Build the XQA module + per-batch buffers eagerly, BEFORE cudagraph capture.
+
+    0.25.1 warmup dummy runs build non-spec metadata (draft=0 -> Phase.DECODE), so no
+    VERIFY-shaped eager call ever reaches xqa_verify before FULL-graph capture; the
+    first call per shape then lands inside capture and the :126 guard declines ->
+    base-FA is baked into every captured graph and the leg silently never fires.
+    Called from FlashAmpereMetadataBuilder.__init__ (pre-capture, eager, has config)."""
+    if not is_supported_page_size(page_size):
+        _log_unsupported_page(page_size)  # expected on mamba-aligned hybrids
+        return
+    _module(q_dtype, kv_dtype, page_size, head_dim, grp, q_seq_len)
+    for n in num_reqs_list:
+        _buffers(n, q_seq_len, Hkv, device)
+    logger.info(
+        "FLASHAMPERE xqa_verify prewarmed (q_seq_len=%d head_dim=%d grp=%d page=%d "
+        "num_reqs=%s)", q_seq_len, head_dim, grp, page_size, num_reqs_list,
+    )
+
+
 def xqa_verify(impl, layer, query, key, value, kv_cache, m, output):
     """MTP verify (uniform q=1+K) through famp's vendored XQA. CUDAGRAPH-SAFE."""
     num_reqs = m.seq_lens.shape[0]
@@ -111,6 +167,8 @@ def xqa_verify(impl, layer, query, key, value, kv_cache, m, output):
         raise KernelDecline
 
     key_cache, value_cache = kv_cache.unbind(1)  # [num_blocks, page_size, Hkv, D] (NHD == XQA NHD)
+    if not is_supported_page_size(key_cache.shape[1]):
+        _decline_page(key_cache.shape[1])  # before the KV write; base FA does its own
     _fa.reshape_and_cache_flash(
         key, value, key_cache, value_cache,
         m.slot_mapping, impl.kv_cache_dtype, layer._k_scale, layer._v_scale,
@@ -124,6 +182,15 @@ def xqa_verify(impl, layer, query, key, value, kv_cache, m, output):
     mod_key = (query.dtype, key_cache.dtype, page_size, D, H // Hkv, q_seq_len)
     buf_key = (num_reqs, q_seq_len, Hkv, dev)
     if (mod_key not in _MODULES or buf_key not in _BUFS) and torch.cuda.is_current_stream_capturing():
+        global _DECLINED_CAPTURE_WARNED
+        if not _DECLINED_CAPTURE_WARNED:
+            _DECLINED_CAPTURE_WARNED = True
+            logger.warning(
+                "FLASHAMPERE xqa_verify declined during capture (mod=%s bufs=%s not "
+                "prewarmed) -> base-FA baked into this graph; prewarm missed this "
+                "shape (mod_key=%s buf_key=%s)",
+                mod_key in _MODULES, buf_key in _BUFS, mod_key, buf_key,
+            )
         raise KernelDecline
 
     try:
@@ -132,8 +199,12 @@ def xqa_verify(impl, layer, query, key, value, kv_cache, m, output):
         raise KernelDecline from e
     sem, seq_u32, mask = _buffers(num_reqs, q_seq_len, Hkv, dev)
 
-    q5 = query.view(num_reqs, 1, q_seq_len, H, D)       # view of the (persistent) query buffer
-    out5 = output.view(num_reqs, 1, q_seq_len, H, D)
+    # The query/output buffers can be cudagraph-padded past the batch's actual tokens
+    # (metadata says nt, the tensor holds the padded graph size) -> slice before the
+    # view; a full-size slice is a no-op view, so this is capture-safe.
+    nt = num_reqs * q_seq_len
+    q5 = query[:nt].view(num_reqs, 1, q_seq_len, H, D)
+    out5 = output[:nt].view(num_reqs, 1, q_seq_len, H, D)
     # Fixed grid for cudagraph: max_seq_len = block_table capacity (constant per captured shape);
     # the kernel handles actual per-request seq_lens (GPU) <= this.
     max_seq_len = int(m.block_table.shape[1]) * page_size

--- a/vllm/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/vllm/v1/spec_decode/llm_base_proposer.py
@@ -362,10 +362,13 @@ class SpecDecodeBaseProposer:
         # for those masked slots.
 
         model_hf_config = self.draft_model_config.hf_config
-        # DFlash stores mask_token_id in dflash_config
+        # DFlash stores mask_token_id in dflash_config; upstream/DeepSeek-official
+        # DSpark exports may carry it at the top level only.
         dflash_config = getattr(model_hf_config, "dflash_config", None)
         if dflash_config and "mask_token_id" in dflash_config:
             self.parallel_drafting_token_id = dflash_config["mask_token_id"]
+        elif getattr(model_hf_config, "mask_token_id", None) is not None:
+            self.parallel_drafting_token_id = model_hf_config.mask_token_id
         elif hasattr(model_hf_config, "pard_token"):
             self.parallel_drafting_token_id = model_hf_config.pard_token
         elif hasattr(model_hf_config, "ptd_token_id"):

--- a/vllm/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/vllm/v1/worker/gpu_model_runner.py
@@ -3882,6 +3882,15 @@ class GPUModelRunner(
             num_reqs=num_reqs,
             force_uniform_decode=force_uniform_decode,
         )
+        # Shape alone misclassifies a prefill whose prompt length equals
+        # uniform_decode_query_len; require every request to be past prefill.
+        if uniform_decode and force_uniform_decode is None:
+            uniform_decode = bool(
+                (
+                    self.input_batch.num_computed_tokens_cpu[:num_reqs]
+                    >= self.input_batch.num_prompt_tokens[:num_reqs]
+                ).all()
+            )
         # Encoder-decoder models only support CG for decoder_step > 0 (no enc_output
         # is present). Also, chunked-prefill is disabled, so batch are uniform.
         has_encoder_output = (


### PR DESCRIPTION
Patch release on v0.4 (same vendored vLLM 0.25.1). Full release-notes copy in `docs/release_notes_v0.4.1.md`.

## Changes

- **Fix (spec-decode correctness):** GDN-hybrid models (Qwen3.6 / Qwen3-Next) + speculative decoding produced garbage when a prompt tokenized to **exactly `num_speculative_tokens + 1` tokens**. Upstream vLLM's `_is_uniform_decode` shape-only check mis-dispatched that prefill through the FULL spec-verify CUDA graph, so the recurrent-state write was skipped and every verify computed from zero state. Method-independent (MTP / DSpark / DFlash / ngram), quantization-independent; dense models unaffected. Filed upstream: vllm-project/vllm#49918 (+ confirmation on PR #47123, which carries the same fix).
- **Fix (flashampere routing):** the 0.25.1 `sliding_window=(-1,-1)` sentinel was treated as a real window, which had disabled **all hd<=256 flashampere routing in the shipped v0.4 image** (including the 27B hd128 flagship). Restored.
- **Fix (flashampere xqa_verify):** the MTP spec-verify leg was silently declining every call at CUDA-graph capture (JIT/alloc is illegal during capture, and no eager VERIFY-shaped warmup call ever preceded it) so stock FA was baked into every captured graph. Now prewarmed at metadata-builder init; cleanly self-disables on mamba-aligned hybrid page geometry (XQA supports pages <=256, hybrids use ~800); padded-batch reshape crash fixed.
- **DSpark:** accepts the upstream / DeepSeek-official head format (`Qwen3DSparkModel`) on the V1 path — one checkpoint now serves both this fork and upstream vLLM >= 0.26.
- **flashampere prefill:** opt-in batched paged-KV prefill (`VLLM_FAMP_BATCH_PREFILL=1`, default off) — +2.3% / +4.5% clean full-prefill @ 4k / 8k; `CTA_TILE_Q=64` on sm86 for hd128 (+6-18% short/mid prefill); sync-free leg dispatch.

## Validation

Full release matrix (`docs/RESEARCH-test-matrix-v05.md`) re-run against this HEAD on 2x3090:

- T0 smoke / zero-delta / kernel CI 622 pass / dispatch pytest 15/15
- T1 famp dispatch + guards; T2 batch-prefill gate boundary exact (294 tok -> no fire, 1184 tok -> fired)
- T5 quality gate: Qwen3.6-27B-W4A16 GSM8K n=100 = 85.0% (in band)
- T6 MTP K=2 accept 2.49, zh-canary 0/8; DFlash K=15 accept 5.86/4.56/4.80
- DSpark upstream-format head: boots, accept 4.11/3.20/3.47, and the original garble repro (K=7 + exactly-8-token prompt, default FULL cudagraph) is **clean**
- Soak: 27B + DSpark tp2, W=16, 20 min -> 3010 requests, 0 errors, VRAM stable

Two packaging findings were caught and are fixed by building the release image from source at this HEAD: the shipped `:latest` was missing `flashampere/prefill/_jit_batch_prefill.py` (batch-prefill opt-in silently inert in the artifact), and the in-image `/opt/famp` copy was stale.